### PR TITLE
Add GitHub templates and contributing guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,40 @@
+name: Chore / Infra
+description: Maintenance, tooling, CI, Docker, repo setup, documentation process
+title: "[Chore] "
+labels: ["type:chore"]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What should be standardized, fixed, or improved?
+      placeholder: Configure...
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What files, services, or areas are affected?
+      placeholder: |
+        Affected areas:
+        - ...
+
+        Not affected:
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: dod
+    attributes:
+      label: Definition of Done
+      description: Checklist that must be completed before closing the issue
+      value: |
+        - [ ] Change implemented
+        - [ ] Verified by team member or locally
+        - [ ] Documentation updated if relevant
+        - [ ] PR created and linked to this issue
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Project README
+    url: https://github.com/lukaszjecek/human-behavior-recognition-in-video-streams
+    about: Read the project setup and workflow instructions first.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,40 @@
+name: Feature
+description: New feature or functional task
+title: "[Feature] "
+labels: ["type:feature"]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What should be achieved?
+      placeholder: Implement...
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What is in scope and what is out of scope?
+      placeholder: |
+        In scope:
+        - ...
+
+        Out of scope:
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: dod
+    attributes:
+      label: Definition of Done
+      description: Checklist that must be completed before closing the issue
+      value: |
+        - [ ] Implementation completed
+        - [ ] Tested locally
+        - [ ] Docs/README updated if relevant
+        - [ ] PR created and linked to this issue
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+Describe what was changed and why.
+
+## Linked Issue
+Closes #
+
+Example: Closes #123 (select the appropriate issue to close)
+
+## Checklist
+- [ ] Changes were tested locally
+- [ ] CI passes
+- [ ] README/docs updated if relevant
+- [ ] Scope matches the linked Issue
+- [ ] No direct work outside the agreed scope

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,9 @@
+## Workflow
+
+- Every task must start as a GitHub Issue.
+- Use the available Issue templates and fill in: Goal, Scope, Definition of Done.
+- Create a feature branch from the Issue.
+- Open a Pull Request using the PR template.
+- In the PR description, link the Issue in the `Linked Issue` section, for example: `Closes #123`.
+- Update documentation when the change affects setup, architecture, API, or usage.
+- Do not commit directly to `main`.


### PR DESCRIPTION
Introduce repository contribution tooling: add issue templates for chores and features (.github/ISSUE_TEMPLATE/chore.yml, feature.yml), a templates config to disable blank issues and add a contact link (.github/ISSUE_TEMPLATE/config.yml), a pull request template (.github/pull_request_template.md), and a contributing guide (docs/contributing.md). The issue templates enforce Goal, Scope, and Definition of Done fields; the PR template provides summary, linked-issue guidance, and a checklist; contributing.md documents the workflow (start tasks as issues, use templates, create feature branches, link issues in PRs, update docs, and avoid committing directly to main).

close #2 