### PR TITLE
Improve CI workflow and local CI docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,18 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
-  ci:
-    name: ci
+  lint-and-test:
+    name: lint-and-test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository
@@ -18,19 +26,17 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: "pip"
 
-      - name: Basic repository sanity check
+      - name: Install dependencies
         run: |
-          test -d .github
-          test -d .github/workflows
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
 
-      - name: Compile Python files if present
-        shell: bash
-        run: |
-          shopt -s globstar nullglob
-          py_files=(**/*.py)
-          if [ ${#py_files[@]} -gt 0 ]; then
-            python -m compileall .
-          else
-            echo "No Python files yet. Skipping Python compilation."
-          fi
+      - name: Lint
+        run: python -m ruff check .
+
+      - name: Run tests
+        env:
+          PYTHONPATH: .
+        run: python -m pytest -q tests

--- a/README.md
+++ b/README.md
@@ -87,3 +87,13 @@ Run lint checks:
 > ```
 > Set-ExecutionPolicy -Scope CurrentUser RemoteSigned
 > ```
+
+
+### Run CI checks locally
+
+```
+python -m pip install --upgrade pip
+pip install -r requirements-dev.txt
+puython -m ruff check .
+python -m pytest -q tests
+```


### PR DESCRIPTION
## Summary
Enhance GitHub Actions CI: add concurrency and cancel-in-progress, grant read permissions for contents, rename job to lint-and-test, set a timeout, enable pip cache in setup-python, install dev dependencies, replace compile/sanity checks with ruff linting and pytest run (with PYTHONPATH set). Update README to include commands for running CI checks locally (install dev requirements, run ruff and pytest).

## Linked Issue
Closes #5 

## Checklist
- [x] Changes were tested locally
- [x] CI passes
- [x] README/docs updated if relevant
- [x] Scope matches the linked Issue
- [x] No direct work outside the agreed scope