### PR TITLE
Add video preprocessing module and tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 pandas==2.2.3
 pyyaml==6.0.1
+torch
+opencv-python
+numpy
+pytest

--- a/src/data/preprocess.py
+++ b/src/data/preprocess.py
@@ -1,0 +1,73 @@
+import cv2
+import numpy as np
+import torch
+from pathlib import Path
+
+
+class VideoPreprocessor:
+    """
+    Module responsible for consistent video preprocessing into tensors.
+
+    Pipeline operations order:
+    1. Decode: Video frame decoding via OpenCV (BGR -> RGB conversion).
+    2. Resize: Scaling to `target_resolution` (W, H).
+    3. Normalize: Casting pixel values from [0, 255] range to [0.0, 1.0].
+    4. Windowing: Extracting temporal windows of length `T` frames with a given `stride`.
+    5. Tensor shape: PyTorch conversion and axis permutation to [T, C, H, W].
+    """
+    def __init__(self, target_resolution: tuple = (224, 224), temporal_window: int = 16, stride: int = 16):
+        self.target_resolution = target_resolution
+        self.T = temporal_window
+        self.stride = stride
+
+    def process(self, video_path: Path) -> torch.Tensor:
+        """
+        Processes the entire video and returns extracted, model-ready windows.
+
+        Returns:
+        torch.Tensor: Tensor of shape [num_windows, T, C, H, W].
+        A single window (before batching) strictly follows the [T, C, H, W] format.
+        """
+        if not video_path.exists():
+            raise FileNotFoundError(f"Video not found: {video_path}")
+
+        cap = cv2.VideoCapture(str(video_path))
+        frames = []
+
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                break
+            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            frame = cv2.resize(frame, self.target_resolution)
+            frames.append(frame)
+
+        cap.release()
+
+        if not frames:
+            return torch.zeros((0, self.T, 3, self.target_resolution[1], self.target_resolution[0]))
+
+        frames_np = np.array(frames, dtype=np.float32) / 255.0
+        total_frames = len(frames_np)
+
+        windows = []
+        for start_idx in range(0, total_frames, self.stride):
+            window = frames_np[start_idx: start_idx + self.T]
+
+            if len(window) < self.T:
+                if len(window) == 0:
+                    continue
+                pad_len = self.T - len(window)
+                padding = np.repeat(window[-1:], pad_len, axis=0)
+                window = np.concatenate([window, padding], axis=0)
+
+            windows.append(window)
+
+        if not windows:
+            return torch.zeros((0, self.T, 3, self.target_resolution[1], self.target_resolution[0]))
+
+        windows_np = np.stack(windows)
+
+        tensor_windows = torch.from_numpy(windows_np).permute(0, 1, 4, 2, 3)
+
+        return tensor_windows

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,42 @@
+import cv2
+import numpy as np
+import pytest
+import torch
+from src.data.preprocess import VideoPreprocessor
+
+
+@pytest.fixture
+def dummy_video(tmp_path):
+    video_path = tmp_path / "test_video.mp4"
+    out = cv2.VideoWriter(
+        str(video_path),
+        cv2.VideoWriter_fourcc(*'mp4v'),
+        30,
+        (320, 240)
+    )
+    for i in range(40):
+        frame = np.full((240, 320, 3), i * 5, dtype=np.uint8)
+        out.write(frame)
+    out.release()
+    return video_path
+
+
+def test_preprocessor_shape_and_stride(dummy_video):
+    preprocessor = VideoPreprocessor(target_resolution=(128, 128), temporal_window=16, stride=16)
+    tensor = preprocessor.process(dummy_video)
+
+    assert tensor.shape == (3, 16, 3, 128, 128)
+
+    preprocessor_32 = VideoPreprocessor(target_resolution=(224, 224), temporal_window=32, stride=10)
+    tensor_32 = preprocessor_32.process(dummy_video)
+
+    assert tensor_32.shape == (4, 32, 3, 224, 224)
+
+
+def test_preprocessor_normalization(dummy_video):
+    preprocessor = VideoPreprocessor()
+    tensor = preprocessor.process(dummy_video)
+
+    assert tensor.dtype == torch.float32
+    assert tensor.min() >= 0.0
+    assert tensor.max() <= 1.0


### PR DESCRIPTION
## Summary
Introduce VideoPreprocessor (src/data/preprocess.py) that decodes video frames via OpenCV, converts BGR->RGB, resizes, normalizes to [0,1], extracts temporal windows with configurable length and stride, pads incomplete windows, and returns tensors shaped [num_windows, T, C, H, W]. Add unit tests (tests/test_preprocess.py) that generate a dummy video and verify output shapes, dtype, and normalization. Update requirements.txt to include torch, opencv-python, numpy, and pytest.

## Linked Issue
Closes #10 

## Checklist
- [x] Changes were tested locally
- [x] CI passes
- [x] README/docs updated if relevant
- [x] Scope matches the linked Issue
- [x] No direct work outside the agreed scope