### PR TITLE
Add video dataset, dataloader and tests

### DIFF
--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -1,0 +1,63 @@
+import json
+from pathlib import Path
+
+import torch
+import yaml
+from torch.utils.data import Dataset, DataLoader
+
+from src.data.preprocess import VideoPreprocessor
+
+
+class VideoDataset(Dataset):
+    """
+    Dataset class that reads a JSONL manifest and prepares video tensors.
+    """
+
+    def __init__(self, manifest_path: Path, data_dir: Path, split: str = "train", config_path: Path = None):
+        self.data_dir = data_dir
+        self.samples = []
+
+        if config_path and config_path.exists():
+            with open(config_path, "r", encoding="utf-8") as f:
+                config = yaml.safe_load(f)
+        else:
+            config = {}
+
+        pipeline_cfg = config.get("pipeline", {})
+        res = pipeline_cfg.get("target_resolution", [224, 224])
+        t_window = pipeline_cfg.get("temporal_window", 16)
+
+        self.preprocessor = VideoPreprocessor(
+            target_resolution=tuple(res),
+            temporal_window=t_window,
+            stride=t_window
+        )
+
+        with open(manifest_path, "r", encoding="utf-8") as f:
+            for line in f:
+                entry = json.loads(line)
+                if entry["split"] == split:
+                    self.samples.append(entry)
+
+        unique_labels = sorted(list(set(s["label"] for s in self.samples)))
+        self.label_to_idx = {label: i for i, label in enumerate(unique_labels)}
+
+    def __len__(self):
+        return len(self.samples)
+
+    def __getitem__(self, idx):
+        sample = self.samples[idx]
+        video_path = self.data_dir / sample["path"]
+
+        windows = self.preprocessor.process(video_path)
+
+        video_tensor = windows[0]
+        label_idx = self.label_to_idx[sample["label"]]
+
+        return video_tensor, torch.tensor(label_idx, dtype=torch.long)
+
+
+def get_dataloader(manifest_path: Path, data_dir: Path, split: str = "train",
+                   batch_size: int = 4, config_path: Path = None) -> DataLoader:
+    dataset = VideoDataset(manifest_path, data_dir, split, config_path)
+    return DataLoader(dataset, batch_size=batch_size, shuffle=(split == "train"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import cv2
+import numpy as np
+import pytest
+
+@pytest.fixture
+def dummy_video(tmp_path):
+    """Creates a 40-frame dummy video in a temporary directory."""
+    video_path = tmp_path / "test_video.mp4"
+    out = cv2.VideoWriter(
+        str(video_path),
+        cv2.VideoWriter_fourcc(*'mp4v'),
+        30,
+        (320, 240)
+    )
+    for i in range(40):
+        frame = np.full((240, 320, 3), i * 5, dtype=np.uint8)
+        out.write(frame)
+    out.release()
+    return video_path

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,40 @@
+import json
+import pytest
+import torch
+from src.data.loader import get_dataloader
+
+
+@pytest.fixture
+def mock_data(tmp_path, dummy_video):
+    """Prepares a mini-manifest and a dummy video for testing."""
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+
+    video_file = raw_dir / "walking" / "test.mp4"
+    video_file.parent.mkdir()
+    video_file.write_bytes(dummy_video.read_bytes())
+
+    manifest_path = tmp_path / "manifest.jsonl"
+    entry = {
+        "video_id": "test_1",
+        "path": "walking/test.mp4",
+        "label": "walking",
+        "split": "train"
+    }
+    with open(manifest_path, "w") as f:
+        f.write(json.dumps(entry) + "\n")
+
+    return manifest_path, raw_dir
+
+
+def test_loader_batch_shape(mock_data):
+    manifest_path, raw_dir = mock_data
+    batch_size = 2
+
+    loader = get_dataloader(manifest_path, raw_dir, split="train", batch_size=batch_size)
+
+    for videos, labels in loader:
+        assert videos.shape == (1, 16, 3, 224, 224)
+        assert labels.shape == (1,)
+        assert videos.dtype == torch.float32
+        break

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,24 +1,6 @@
-import cv2
-import numpy as np
-import pytest
 import torch
 from src.data.preprocess import VideoPreprocessor
 
-
-@pytest.fixture
-def dummy_video(tmp_path):
-    video_path = tmp_path / "test_video.mp4"
-    out = cv2.VideoWriter(
-        str(video_path),
-        cv2.VideoWriter_fourcc(*'mp4v'),
-        30,
-        (320, 240)
-    )
-    for i in range(40):
-        frame = np.full((240, 320, 3), i * 5, dtype=np.uint8)
-        out.write(frame)
-    out.release()
-    return video_path
 
 
 def test_preprocessor_shape_and_stride(dummy_video):


### PR DESCRIPTION
## Summary
Introduce VideoDataset and get_dataloader (src/data/loader.py) to load samples from a JSONL manifest, apply VideoPreprocessor (configurable via optional YAML pipeline settings), map labels to indices, and return torch tensors. Add pytest fixtures (tests/conftest.py) to create a dummy video and a new test (tests/test_loader.py) validating dataloader batch shape, dtype, and label shape. Update tests/test_preprocess.py to remove a duplicated dummy_video fixture and rely on the shared conftest fixture.

## Linked Issue
Closes #11 

## Checklist
- [x] Changes were tested locally
- [x] CI passes
- [x] README/docs updated if relevant
- [x] Scope matches the linked Issue
- [x] No direct work outside the agreed scope