### PR TITLE
Update CODEOWNERS and update README about reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,26 @@
+# fallback ownership
 * @lukaszjecek
+
+# lukaszjecek ownership
+/.github/                @lukaszjecek
+/docker/                 @lukaszjecek
+/docs/                   @lukaszjecek
+/.dockerignore           @lukaszjecek
+/.gitattributes          @lukaszjecek
+/.gitignore              @lukaszjecek
+/compose.yaml            @lukaszjecek
+/pytest.ini              @lukaszjecek
+/README.md               @lukaszjecek
+/requirements*.txt       @lukaszjecek
+
+
+# alicjaswiers ownership
+/configs/                @alicjaswiers
+/data/                   @alicjaswiers
+/docs/data_pipeline.md   @alicjaswiers
+
+
+# shared ownership
+/scripts/                @alicjaswiers @lukaszjecek
+/src/                    @alicjaswiers @lukaszjecek
+/tests/                  @alicjaswiers @lukaszjecek

--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ docker compose up --build
 - Do not commit directly to `main`.    
 - All changes must be made on a feature branch and merged through a Pull Request.    
 - Each Pull Request requires at least 1 approving review before merge.    
-- Direct pushes to `main` are blocked by repository rules.    
+- Direct pushes to `main` are blocked by repository rules.
+- Repository ownership is defined in `.github/CODEOWNERS`.
+- When a Pull Request changes files owned by specific contributors, GitHub automatically requests their review once the PR is ready for review.
+- Changes in owned areas should be approved by the relevant code owner before merge. Such approval is mandatory for merging.
     
 ### Branch naming    
  Use descriptive branch names, for example:    


### PR DESCRIPTION
## Summary
Update a .github/CODEOWNERS file to assign ownership across the repository (fallback owner, per-directory owners, and shared owners for scripts/src/tests). Update README to reference the CODEOWNERS file and clarify that repository ownership will trigger mandatory review requests from code owners and that owned-area approvals are required before merging.

## Linked Issue
Closes #31 

## Checklist
- [x] Changes were tested locally
- [x] CI passes
- [x] README/docs updated if relevant
- [x] Scope matches the linked Issue
- [x] No direct work outside the agreed scope