### PR TITLE
Implement FIFO frame buffer and sliding window logic in inference engine

### DIFF
--- a/src/inference/buffer.py
+++ b/src/inference/buffer.py
@@ -1,0 +1,56 @@
+import collections
+from typing import Any, List
+
+
+class FrameBuffer:
+    """
+    Fixed-size FIFO data structure for buffering video frames 
+    for real-time inference.
+    """
+
+    def __init__(self, window_size: int = 16):
+        """
+        Initializes the buffer.
+
+        Args:
+            window_size (int): Maximum number of frames stored in the window.
+        """
+        if window_size <= 0:
+            raise ValueError(
+                "Window size must be greater than 0.")
+
+        self.window_size = window_size
+        # deque with maxlen automatically removes the oldest elements upon overflow
+        self.buffer = collections.deque(maxlen=window_size)
+
+    def append(self, frame: Any) -> None:
+        """
+        Appends a new frame to the buffer. If the buffer is full, 
+        the oldest frame is automatically removed.
+        """
+        self.buffer.append(frame)
+
+    def get_window(self) -> List[Any]:
+        """
+        Returns the current buffer content as a list.
+        """
+        return list(self.buffer)
+
+    def is_full(self) -> bool:
+        """
+        Checks if the buffer has reached its target size.
+        """
+        return len(self.buffer) == self.window_size
+
+    def clear(self) -> None:
+        """
+        Clears the buffer content.
+        """
+        self.buffer.clear()
+
+    @property
+    def current_size(self) -> int:
+        """
+        Returns the current number of frames in the buffer.
+        """
+        return len(self.buffer)

--- a/src/inference/buffer.py
+++ b/src/inference/buffer.py
@@ -4,7 +4,7 @@ from typing import Any, List
 
 class FrameBuffer:
     """
-    Fixed-size FIFO data structure for buffering video frames 
+    Fixed-size FIFO data structure for buffering video frames
     for real-time inference.
     """
 

--- a/src/inference/buffer.py
+++ b/src/inference/buffer.py
@@ -4,7 +4,7 @@ from typing import Any, List
 
 class FrameBuffer:
     """
-    Fixed-size FIFO data structure for buffering video frames 
+    Fixed-size FIFO data structure for buffering video frames
     for real-time inference.
     """
 
@@ -16,16 +16,21 @@ class FrameBuffer:
             window_size (int): Maximum number of frames stored in the window.
         """
         if window_size <= 0:
-            raise ValueError(
-                "Window size must be greater than 0.")
+            raise ValueError("Window size must be greater than 0.")
 
-        self.window_size = window_size
         # deque with maxlen automatically removes the oldest elements upon overflow
         self.buffer = collections.deque(maxlen=window_size)
 
+    @property
+    def window_size(self) -> int:
+        """
+        Returns the maximum capacity of the buffer (read-only).
+        """
+        return self.buffer.maxlen
+
     def append(self, frame: Any) -> None:
         """
-        Appends a new frame to the buffer. If the buffer is full, 
+        Appends a new frame to the buffer. If the buffer is full,
         the oldest frame is automatically removed.
         """
         self.buffer.append(frame)
@@ -40,7 +45,7 @@ class FrameBuffer:
         """
         Checks if the buffer has reached its target size.
         """
-        return len(self.buffer) == self.window_size
+        return len(self.buffer) == self.buffer.maxlen
 
     def clear(self) -> None:
         """

--- a/src/inference/engine.py
+++ b/src/inference/engine.py
@@ -1,0 +1,40 @@
+from typing import Any, Optional
+from src.inference.buffer import FrameBuffer
+
+
+class InferenceEngine:
+    """
+    Core engine for processing real-time video streams and predicting human behavior.
+    """
+
+    def __init__(self, window_size: int = 16, model: Optional[Any] = None):
+        """
+        Initializes the InferenceEngine.
+
+        Args:
+            window_size (int): The number of frames required to make a prediction.
+            model (Any, optional): The behavior recognition model (e.g., PyTorch nn.Module).
+        """
+        self.buffer = FrameBuffer(window_size=window_size)
+        self.model = model
+
+    def process_frame(self, frame: Any) -> Optional[Any]:
+        """
+        Adds a new frame to the temporal buffer and triggers inference if the buffer is full.
+
+        Args:
+            frame (Any): A single video frame.
+
+        Returns:
+            Optional[Any]: The prediction result if the buffer is full and a model is loaded, 
+                           otherwise None.
+        """
+        self.buffer.append(frame)
+
+        if self.buffer.is_full() and self.model is not None:
+            # TODO: Implement actual tensor preprocessing and model forward pass
+            # window = self.buffer.get_window()
+            # return self.model(window)
+            return "prediction_stub"
+
+        return None

--- a/tests/inference/test_buffer.py
+++ b/tests/inference/test_buffer.py
@@ -53,3 +53,21 @@ def test_configurable_window_size():
 
     with pytest.raises(ValueError):
         FrameBuffer(window_size=-5)
+
+
+def test_clear_buffer():
+    """Test clearing the buffer content."""
+    buf = FrameBuffer(window_size=5)
+    buf.append("frame_1")
+    buf.append("frame_2")
+
+    # Verify the buffer has elements before clearing
+    assert buf.current_size == 2
+
+    # Clear the buffer
+    buf.clear()
+
+    # Verify the state after clearing
+    assert buf.current_size == 0
+    assert buf.is_full() is False
+    assert buf.get_window() == []

--- a/tests/inference/test_engine.py
+++ b/tests/inference/test_engine.py
@@ -1,0 +1,27 @@
+from src.inference.engine import InferenceEngine
+
+
+def test_inference_engine_initialization():
+    """Test if the engine initializes correctly with the frame buffer."""
+    engine = InferenceEngine(window_size=16)
+
+    assert engine.buffer.window_size == 16
+    assert engine.model is None
+
+
+def test_inference_engine_process_frame():
+    """Test the frame processing logic and stub prediction trigger."""
+    class DummyModel:
+        pass  # Just a placeholder for testing
+
+    engine = InferenceEngine(window_size=3, model=DummyModel())
+
+    # Buffer is not full yet
+    assert engine.process_frame("frame_1") is None
+    assert engine.process_frame("frame_2") is None
+
+    # Buffer is now full, it should trigger inference and return the stub prediction
+    assert engine.process_frame("frame_3") == "prediction_stub"
+
+    # Next frame shifts the window (overflow), it should still predict
+    assert engine.process_frame("frame_4") == "prediction_stub"

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -1,0 +1,55 @@
+import pytest
+from src.inference.buffer import FrameBuffer
+
+
+def test_empty_buffer():
+    """Test the behavior of an empty buffer."""
+    buf = FrameBuffer(window_size=16)
+
+    assert buf.current_size == 0
+    assert buf.is_full() is False
+    assert buf.get_window() == []
+
+
+def test_partial_buffer():
+    """Test the behavior of a partially filled buffer."""
+    buf = FrameBuffer(window_size=5)
+    buf.append("frame_1")
+    buf.append("frame_2")
+
+    assert buf.current_size == 2
+    assert buf.is_full() is False
+    assert buf.get_window() == ["frame_1", "frame_2"]
+
+
+def test_full_buffer_and_overflow():
+    """Test buffer overflow and automatic removal of the oldest frames."""
+    buf = FrameBuffer(window_size=3)
+    buf.append("f1")
+    buf.append("f2")
+    buf.append("f3")
+
+    assert buf.is_full() is True
+    assert buf.get_window() == ["f1", "f2", "f3"]
+
+    # Adding a new frame after the buffer is full (overflow - removes f1)
+    buf.append("f4")
+    assert buf.is_full() is True
+    assert buf.get_window() == ["f2", "f3", "f4"]
+
+    # Another overflow (removes f2)
+    buf.append("f5")
+    assert buf.get_window() == ["f3", "f4", "f5"]
+
+
+def test_configurable_window_size():
+    """Test window size configuration and input validation."""
+    buf = FrameBuffer(window_size=32)
+    assert buf.window_size == 32
+
+    # Check if ValueError is raised for invalid input
+    with pytest.raises(ValueError):
+        FrameBuffer(window_size=0)
+
+    with pytest.raises(ValueError):
+        FrameBuffer(window_size=-5)


### PR DESCRIPTION
## Summary
Implemented the core temporal buffering logic required by the InferenceEngine. 

Added a new `FrameBuffer` class in `src/inference/buffer.py` that utilizes Python's `collections.deque` with a `maxlen` parameter. This ensures a highly efficient, fixed-size FIFO window where the oldest frames are automatically discarded as new ones arrive in `O(1)` time. 

Key additions:
* Configurable window size (e.g., 16 or 32 frames).
* Automatic overflow handling.
* Comprehensive unit tests in `tests/inference/test_buffer.py` covering empty, partial, full, and overflow states, as well as input validation.

## Linked Issue
Closes #42 

## Checklist
- [x] Changes were tested locally
- [x] CI passes
- [x] Scope matches the linked Issue
- [x] No direct work outside the agreed scope