### PR TITLE
43 feature add stride based inference scheduling and window snapshot api

### DIFF
--- a/src/inference/engine.py
+++ b/src/inference/engine.py
@@ -1,4 +1,5 @@
-from typing import Any, Optional
+import copy
+from typing import Any, Optional, List
 from src.inference.buffer import FrameBuffer
 
 
@@ -7,34 +8,68 @@ class InferenceEngine:
     Core engine for processing real-time video streams and predicting human behavior.
     """
 
-    def __init__(self, window_size: int = 16, model: Optional[Any] = None):
+    def __init__(self, window_size: int = 16, stride: int = 1, model: Optional[Any] = None):
         """
         Initializes the InferenceEngine.
 
         Args:
             window_size (int): The number of frames required to make a prediction.
+            stride (int): The number of frames to skip before triggering the next inference.
             model (Any, optional): The behavior recognition model (e.g., PyTorch nn.Module).
         """
+        if stride <= 0:
+            raise ValueError("Stride must be greater than 0")
+
+        if window_size <= 0:
+            raise ValueError("window_size must be greater than 0")
+
         self.buffer = FrameBuffer(window_size=window_size)
+        self.stride = stride
         self.model = model
+
+        # Counter to track the total number of processed frames
+        self.frame_count: int = 0
+
+        # Stores the exact window of frames used in the most recent valid inference
+        self._latest_inference_window: Optional[List[Any]] = None
 
     def process_frame(self, frame: Any) -> Optional[Any]:
         """
-        Adds a new frame to the temporal buffer and triggers inference if the buffer is full.
+        Adds a new frame to the temporal buffer and triggers inference based on the stride logic.
 
         Args:
             frame (Any): A single video frame.
 
         Returns:
-            Optional[Any]: The prediction result if the buffer is full and a model is loaded, 
-                           otherwise None.
+            Optional[Any]: The prediction result if inference is triggered, otherwise None.
         """
+        self.frame_count += 1
         self.buffer.append(frame)
 
-        if self.buffer.is_full() and self.model is not None:
-            # TODO: Implement actual tensor preprocessing and model forward pass
-            # window = self.buffer.get_window()
-            # return self.model(window)
-            return "prediction_stub"
+        # We only trigger inference if the buffer is completely full
+        if self.buffer.is_full():
+            # Calculate how many frames have passed since the buffer first filled up
+            frames_since_full = self.frame_count - self.buffer.window_size
+
+            # Trigger inference on the very first full window, and then exactly every `stride` frames
+            if frames_since_full % self.stride == 0:
+                self._latest_inference_window = copy.deepcopy(
+                    self.buffer.get_window())
+
+                if self.model is not None:
+                    # TODO: Implement actual tensor preprocessing and model forward pass
+                    # window = self.get_latest_window()
+                    # return self.model(window)
+                    return "prediction_stub"
 
         return None
+
+    def get_latest_window(self) -> Optional[List[Any]]:
+        """
+        Returns the most recent temporal window on which inference was triggered.
+        This provides a clear API to retrieve valid frames regardless of the current buffer state.
+
+        Returns:
+            Optional[List[Any]]: A list of frames, or None if no inference has been triggered yet.
+        """
+        return self._latest_inference_window

--- a/src/inference/engine.py
+++ b/src/inference/engine.py
@@ -81,6 +81,7 @@ class InferenceEngine:
         # Result tracking
         self._latest_result: Optional[InferenceResult] = None
         self._unread_result: bool = False  # Track if there is a new, unconsumed result
+        self._inference_active: bool = False
 
         # Metrics
         self.total_inferences: int = 0
@@ -133,18 +134,11 @@ class InferenceEngine:
         frame: Any,
         timestamp: Optional[float] = None
     ) -> Optional[InferenceResult]:
-        """
-        Processes a single frame.
 
-        Returns:
-            InferenceResult if triggered
-            None otherwise
-        """
         if timestamp is None:
             timestamp = time.time()
 
         with self._lock:
-
             self.frame_count += 1
             self.total_frames_processed += 1
 
@@ -154,44 +148,54 @@ class InferenceEngine:
             if not self.buffer.is_full():
                 return None
 
-            if not self._should_trigger_inference():
+            if self._inference_active or not self._should_trigger_inference():
                 self.total_frames_skipped += 1
                 return None
 
-            # Prepare immutable snapshot for the model
+            self._inference_active = True
+
             window_snapshot = tuple(self.buffer.get_window())
             start_frame_snap = self.frame_count - self.window_size + 1
             end_frame_snap = self.frame_count
             start_ts_snap = self._timestamps[0]
             end_ts_snap = self._timestamps[-1]
 
-            self._last_inference_frame = self.frame_count
-            self.total_inferences += 1
-
         prediction = None
 
-        if self.model is not None:
-            if callable(self.model):
-                prediction = self.model(window_snapshot)
-            elif hasattr(self.model, "predict"):
-                prediction = self.model.predict(window_snapshot)
-            else:
-                logger.warning(
-                    "Model is neither callable nor has a predict() method"
-                )
+        try:
+            if self.model is not None:
+                if callable(self.model):
+                    prediction = self.model(window_snapshot)
+                elif hasattr(self.model, "predict"):
+                    prediction = self.model.predict(window_snapshot)
+                else:
+                    logger.warning(
+                        "Model is neither callable nor has a predict() method")
 
-        result = InferenceResult(
-            window=window_snapshot,
-            start_frame_index=start_frame_snap,
-            end_frame_index=end_frame_snap,
-            start_timestamp=start_ts_snap,
-            end_timestamp=end_ts_snap,
-            prediction=prediction
-        )
+            result = InferenceResult(
+                window=window_snapshot,
+                start_frame_index=start_frame_snap,
+                end_frame_index=end_frame_snap,
+                start_timestamp=start_ts_snap,
+                end_timestamp=end_ts_snap,
+                prediction=prediction
+            )
+
+        except Exception as e:
+            with self._lock:
+                self._inference_active = False
+            logger.error(
+                "Inference failed due to an exception.", exc_info=True)
+            raise e
 
         with self._lock:
+            # Update after success
+            self._last_inference_frame = end_frame_snap
+            self.total_inferences += 1
+
             self._latest_result = result
             self._unread_result = True
+            self._inference_active = False
 
             logger.debug(
                 "Inference completed (frames %d-%d)",

--- a/src/inference/engine.py
+++ b/src/inference/engine.py
@@ -148,7 +148,6 @@ class InferenceEngine:
             self.total_frames_processed += 1
 
             self.buffer.append(frame)
-
             self._timestamps.append(timestamp)
 
             if len(self._timestamps) > self.window_size:
@@ -161,8 +160,48 @@ class InferenceEngine:
                 self.total_frames_skipped += 1
                 return None
 
-            result = self._run_inference()
-            return result
+            # Prepare immutable snapshot for the model
+            window_snapshot = tuple(self.buffer.get_window())
+            start_frame_snap = self.frame_count - self.window_size + 1
+            end_frame_snap = self.frame_count
+            start_ts_snap = self._timestamps[0]
+            end_ts_snap = self._timestamps[-1]
+
+            self._last_inference_frame = self.frame_count
+            self.total_inferences += 1
+
+        prediction = None
+
+        if self.model is not None:
+            if callable(self.model):
+                prediction = self.model(window_snapshot)
+            elif hasattr(self.model, "predict"):
+                prediction = self.model.predict(window_snapshot)
+            else:
+                logger.warning(
+                    "Model is neither callable nor has a predict() method"
+                )
+
+        result = InferenceResult(
+            window=window_snapshot,
+            start_frame_index=start_frame_snap,
+            end_frame_index=end_frame_snap,
+            start_timestamp=start_ts_snap,
+            end_timestamp=end_ts_snap,
+            prediction=prediction
+        )
+
+        with self._lock:
+            self._latest_result = result
+            self._unread_result = True
+
+            logger.debug(
+                "Inference completed (frames %d-%d)",
+                start_frame_snap,
+                end_frame_snap
+            )
+
+        return result
 
     # ========================
     # Internal logic
@@ -179,66 +218,6 @@ class InferenceEngine:
         )
 
         return frames_since_last >= self._stride
-
-    def _run_inference(self) -> InferenceResult:
-
-        # Cast to tuple to ensure immutability and protect engine state
-        window = tuple(self.buffer.get_window())
-
-        if len(window) != self.window_size:
-            raise RuntimeError(
-                "Buffer returned invalid window size"
-            )
-
-        start_frame = (
-            self.frame_count
-            - self.window_size
-            + 1
-        )
-
-        end_frame = self.frame_count
-
-        start_ts = self._timestamps[0]
-        end_ts = self._timestamps[-1]
-
-        prediction = None
-
-        if self.model is not None:
-            # Check for PyTorch nn.Module style callable
-            if callable(self.model):
-                prediction = self.model(window)
-            # Check for Scikit-learn style predict()
-            elif hasattr(self.model, "predict"):
-                prediction = self.model.predict(window)
-            else:
-                logger.warning(
-                    "Model is neither callable nor has a predict() method"
-                )
-
-        result = InferenceResult(
-            window=window,
-            start_frame_index=start_frame,
-            end_frame_index=end_frame,
-            start_timestamp=start_ts,
-            end_timestamp=end_ts,
-            prediction=prediction
-        )
-
-        self._latest_result = result
-        self._unread_result = True  # Mark result as fresh
-
-        self._last_inference_frame = self.frame_count
-
-        self.total_inferences += 1
-
-        logger.debug(
-            "Inference triggered "
-            "(frames %d-%d)",
-            start_frame,
-            end_frame
-        )
-
-        return result
 
     # ========================
     # API helpers

--- a/src/inference/engine.py
+++ b/src/inference/engine.py
@@ -185,7 +185,7 @@ class InferenceEngine:
                 prediction=prediction
             )
 
-        except Exception as e:
+        except Exception:
             with self._lock:
                 if self._generation == current_generation:
                     self._inference_active = False

--- a/src/inference/engine.py
+++ b/src/inference/engine.py
@@ -1,5 +1,5 @@
 import collections
-from typing import Any, Optional, List, Tuple
+from typing import Any, Optional, Tuple
 from dataclasses import dataclass
 from threading import Lock
 import logging

--- a/src/inference/engine.py
+++ b/src/inference/engine.py
@@ -42,8 +42,7 @@ class InferenceEngine:
         self,
         window_size: int = 16,
         stride: int = 1,
-        model: Optional[Any] = None,
-        copy_window: bool = True
+        model: Optional[Any] = None
     ):
         """
         Args:
@@ -54,12 +53,7 @@ class InferenceEngine:
                 Frames between inference triggers.
 
             model:
-                Optional model object with:
-                    predict(window)
-
-            copy_window:
-                Whether window should be copied
-                before storing result.
+                Optional model object (callable PyTorch model or object with predict()).
         """
 
         if window_size <= 0:
@@ -69,13 +63,8 @@ class InferenceEngine:
             raise ValueError("stride must be > 0")
 
         self.buffer = FrameBuffer(window_size=window_size)
-
-        self.window_size = window_size
         self._stride = stride
-
         self.model = model
-
-        self.copy_window = copy_window
 
         # Thread safety
         self._lock = Lock()
@@ -89,8 +78,9 @@ class InferenceEngine:
         # Last inference location
         self._last_inference_frame: Optional[int] = None
 
-        # Last result
+        # Result tracking
         self._latest_result: Optional[InferenceResult] = None
+        self._unread_result: bool = False  # Track if there is a new, unconsumed result
 
         # Metrics
         self.total_inferences: int = 0
@@ -109,6 +99,13 @@ class InferenceEngine:
     # ========================
 
     @property
+    def window_size(self) -> int:
+        """
+        Single Source of Truth for window_size, delegated to the buffer.
+        """
+        return self.buffer.window_size
+
+    @property
     def stride(self) -> int:
         return self._stride
 
@@ -116,7 +113,6 @@ class InferenceEngine:
         """
         Dynamically updates stride.
         """
-
         if stride <= 0:
             raise ValueError("stride must be > 0")
 
@@ -126,7 +122,6 @@ class InferenceEngine:
                 self._stride,
                 stride
             )
-
             self._stride = stride
 
     # ========================
@@ -145,7 +140,6 @@ class InferenceEngine:
             InferenceResult if triggered
             None otherwise
         """
-
         if timestamp is None:
             timestamp = time.time()
 
@@ -165,12 +159,10 @@ class InferenceEngine:
                 return None
 
             if not self._should_trigger_inference():
-
                 self.total_frames_skipped += 1
                 return None
 
             result = self._run_inference()
-
             return result
 
     # ========================
@@ -191,15 +183,13 @@ class InferenceEngine:
 
     def _run_inference(self) -> InferenceResult:
 
+        # get_window() in FrameBuffer already returns a fresh list (shallow copy)
         window = self.buffer.get_window()
 
         if len(window) != self.window_size:
             raise RuntimeError(
                 "Buffer returned invalid window size"
             )
-
-        if self.copy_window:
-            window = list(window)
 
         start_frame = (
             self.frame_count
@@ -215,15 +205,15 @@ class InferenceEngine:
         prediction = None
 
         if self.model is not None:
-
-            if hasattr(self.model, "predict"):
-
+            # Check for PyTorch nn.Module style callable
+            if callable(self.model):
+                prediction = self.model(window)
+            # Check for Scikit-learn style predict()
+            elif hasattr(self.model, "predict"):
                 prediction = self.model.predict(window)
-
             else:
-
                 logger.warning(
-                    "Model has no predict() method"
+                    "Model is neither callable nor has a predict() method"
                 )
 
         result = InferenceResult(
@@ -236,6 +226,7 @@ class InferenceEngine:
         )
 
         self._latest_result = result
+        self._unread_result = True  # Mark result as fresh
 
         self._last_inference_frame = self.frame_count
 
@@ -259,12 +250,13 @@ class InferenceEngine:
     ) -> Optional[InferenceResult]:
 
         with self._lock:
-
+            self._unread_result = False  # Result consumed
             return self._latest_result
 
     def has_new_result(self) -> bool:
 
-        return self._latest_result is not None
+        with self._lock:
+            return self._unread_result
 
     def peek_next_trigger_frame(
         self
@@ -317,6 +309,7 @@ class InferenceEngine:
             self._last_inference_frame = None
 
             self._latest_result = None
+            self._unread_result = False
 
             self.total_inferences = 0
             self.total_frames_processed = 0

--- a/src/inference/engine.py
+++ b/src/inference/engine.py
@@ -186,7 +186,7 @@ class InferenceEngine:
                 self._inference_active = False
             logger.error(
                 "Inference failed due to an exception.", exc_info=True)
-            raise e
+            raise
 
         with self._lock:
             # Update after success

--- a/src/inference/engine.py
+++ b/src/inference/engine.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, List
+from typing import Any, Optional, List, Tuple
 from dataclasses import dataclass
 from threading import Lock
 import logging
@@ -9,13 +9,12 @@ from src.inference.buffer import FrameBuffer
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(frozen=True)
 class InferenceResult:
     """
     Stores metadata and prediction for an inference step.
     """
-
-    window: List[Any]
+    window: Tuple[Any, ...]
 
     start_frame_index: int
     end_frame_index: int
@@ -183,8 +182,8 @@ class InferenceEngine:
 
     def _run_inference(self) -> InferenceResult:
 
-        # get_window() in FrameBuffer already returns a fresh list (shallow copy)
-        window = self.buffer.get_window()
+        # Cast to tuple to ensure immutability and protect engine state
+        window = tuple(self.buffer.get_window())
 
         if len(window) != self.window_size:
             raise RuntimeError(

--- a/src/inference/engine.py
+++ b/src/inference/engine.py
@@ -83,6 +83,9 @@ class InferenceEngine:
         self._unread_result: bool = False  # Track if there is a new, unconsumed result
         self._inference_active: bool = False
 
+        # Generation token for state invalidation across locks
+        self._generation: int = 0
+
         # Metrics
         self.total_inferences: int = 0
         self.total_frames_processed: int = 0
@@ -153,6 +156,7 @@ class InferenceEngine:
                 return None
 
             self._inference_active = True
+            current_generation = self._generation
 
             window_snapshot = tuple(self.buffer.get_window())
             start_frame_snap = self.frame_count - self.window_size + 1
@@ -183,13 +187,18 @@ class InferenceEngine:
 
         except Exception as e:
             with self._lock:
-                self._inference_active = False
+                if self._generation == current_generation:
+                    self._inference_active = False
             logger.error(
                 "Inference failed due to an exception.", exc_info=True)
-            raise e
+            raise
 
         with self._lock:
-            # Update after success
+            if self._generation != current_generation:
+                logger.debug(
+                    "Stale inference detected due to reset. Discarding result.")
+                return None
+
             self._last_inference_frame = end_frame_snap
             self.total_inferences += 1
 
@@ -275,21 +284,19 @@ class InferenceEngine:
             }
 
     def reset(self):
-
         with self._lock:
-
             logger.info("Engine reset")
 
             self.buffer.clear()
-
             self.frame_count = 0
-
             self._timestamps.clear()
 
             self._last_inference_frame = None
-
             self._latest_result = None
             self._unread_result = False
+
+            self._inference_active = False
+            self._generation += 1
 
             self.total_inferences = 0
             self.total_frames_processed = 0

--- a/src/inference/engine.py
+++ b/src/inference/engine.py
@@ -1,3 +1,4 @@
+import collections
 from typing import Any, Optional, List, Tuple
 from dataclasses import dataclass
 from threading import Lock
@@ -72,7 +73,7 @@ class InferenceEngine:
         self.frame_count: int = 0
 
         # Timestamp tracking
-        self._timestamps: List[Optional[float]] = []
+        self._timestamps = collections.deque(maxlen=window_size)
 
         # Last inference location
         self._last_inference_frame: Optional[int] = None
@@ -149,9 +150,6 @@ class InferenceEngine:
 
             self.buffer.append(frame)
             self._timestamps.append(timestamp)
-
-            if len(self._timestamps) > self.window_size:
-                self._timestamps.pop(0)
 
             if not self.buffer.is_full():
                 return None

--- a/src/inference/engine.py
+++ b/src/inference/engine.py
@@ -1,75 +1,323 @@
-import copy
 from typing import Any, Optional, List
+from dataclasses import dataclass
+from threading import Lock
+import logging
+import time
+
 from src.inference.buffer import FrameBuffer
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class InferenceResult:
+    """
+    Stores metadata and prediction for an inference step.
+    """
+
+    window: List[Any]
+
+    start_frame_index: int
+    end_frame_index: int
+
+    start_timestamp: Optional[float]
+    end_timestamp: Optional[float]
+
+    prediction: Optional[Any]
 
 
 class InferenceEngine:
     """
-    Core engine for processing real-time video streams and predicting human behavior.
+    Production-grade inference engine with:
+
+    - configurable stride
+    - frame + timestamp tracking
+    - deterministic windowing
+    - thread safety
+    - logging
+    - metrics
     """
 
-    def __init__(self, window_size: int = 16, stride: int = 1, model: Optional[Any] = None):
+    def __init__(
+        self,
+        window_size: int = 16,
+        stride: int = 1,
+        model: Optional[Any] = None,
+        copy_window: bool = True
+    ):
         """
-        Initializes the InferenceEngine.
-
         Args:
-            window_size (int): The number of frames required to make a prediction.
-            stride (int): The number of frames to skip before triggering the next inference.
-            model (Any, optional): The behavior recognition model (e.g., PyTorch nn.Module).
+            window_size:
+                Number of frames per inference window.
+
+            stride:
+                Frames between inference triggers.
+
+            model:
+                Optional model object with:
+                    predict(window)
+
+            copy_window:
+                Whether window should be copied
+                before storing result.
         """
-        if stride <= 0:
-            raise ValueError("Stride must be greater than 0")
 
         if window_size <= 0:
-            raise ValueError("window_size must be greater than 0")
+            raise ValueError("window_size must be > 0")
+
+        if stride <= 0:
+            raise ValueError("stride must be > 0")
 
         self.buffer = FrameBuffer(window_size=window_size)
-        self.stride = stride
+
+        self.window_size = window_size
+        self._stride = stride
+
         self.model = model
 
-        # Counter to track the total number of processed frames
+        self.copy_window = copy_window
+
+        # Thread safety
+        self._lock = Lock()
+
+        # Frame tracking
         self.frame_count: int = 0
 
-        # Stores the exact window of frames used in the most recent valid inference
-        self._latest_inference_window: Optional[List[Any]] = None
+        # Timestamp tracking
+        self._timestamps: List[Optional[float]] = []
 
-    def process_frame(self, frame: Any) -> Optional[Any]:
+        # Last inference location
+        self._last_inference_frame: Optional[int] = None
+
+        # Last result
+        self._latest_result: Optional[InferenceResult] = None
+
+        # Metrics
+        self.total_inferences: int = 0
+        self.total_frames_processed: int = 0
+        self.total_frames_skipped: int = 0
+
+        logger.debug(
+            "InferenceEngine initialized "
+            "(window=%d stride=%d)",
+            window_size,
+            stride
+        )
+
+    # ========================
+    # Public properties
+    # ========================
+
+    @property
+    def stride(self) -> int:
+        return self._stride
+
+    def set_stride(self, stride: int):
         """
-        Adds a new frame to the temporal buffer and triggers inference based on the stride logic.
+        Dynamically updates stride.
+        """
 
-        Args:
-            frame (Any): A single video frame.
+        if stride <= 0:
+            raise ValueError("stride must be > 0")
+
+        with self._lock:
+            logger.info(
+                "Stride changed from %d to %d",
+                self._stride,
+                stride
+            )
+
+            self._stride = stride
+
+    # ========================
+    # Core processing
+    # ========================
+
+    def process_frame(
+        self,
+        frame: Any,
+        timestamp: Optional[float] = None
+    ) -> Optional[InferenceResult]:
+        """
+        Processes a single frame.
 
         Returns:
-            Optional[Any]: The prediction result if inference is triggered, otherwise None.
+            InferenceResult if triggered
+            None otherwise
         """
-        self.frame_count += 1
-        self.buffer.append(frame)
 
-        # We only trigger inference if the buffer is completely full
-        if self.buffer.is_full():
-            # Calculate how many frames have passed since the buffer first filled up
-            frames_since_full = self.frame_count - self.buffer.window_size
+        if timestamp is None:
+            timestamp = time.time()
 
-            # Trigger inference on the very first full window, and then exactly every `stride` frames
-            if frames_since_full % self.stride == 0:
-                self._latest_inference_window = copy.deepcopy(
-                    self.buffer.get_window())
+        with self._lock:
 
-                if self.model is not None:
-                    # TODO: Implement actual tensor preprocessing and model forward pass
-                    # window = self.get_latest_window()
-                    # return self.model(window)
-                    return "prediction_stub"
+            self.frame_count += 1
+            self.total_frames_processed += 1
 
-        return None
+            self.buffer.append(frame)
 
-    def get_latest_window(self) -> Optional[List[Any]]:
+            self._timestamps.append(timestamp)
+
+            if len(self._timestamps) > self.window_size:
+                self._timestamps.pop(0)
+
+            if not self.buffer.is_full():
+                return None
+
+            if not self._should_trigger_inference():
+
+                self.total_frames_skipped += 1
+                return None
+
+            result = self._run_inference()
+
+            return result
+
+    # ========================
+    # Internal logic
+    # ========================
+
+    def _should_trigger_inference(self) -> bool:
+
+        if self._last_inference_frame is None:
+            return True
+
+        frames_since_last = (
+            self.frame_count
+            - self._last_inference_frame
+        )
+
+        return frames_since_last >= self._stride
+
+    def _run_inference(self) -> InferenceResult:
+
+        window = self.buffer.get_window()
+
+        if len(window) != self.window_size:
+            raise RuntimeError(
+                "Buffer returned invalid window size"
+            )
+
+        if self.copy_window:
+            window = list(window)
+
+        start_frame = (
+            self.frame_count
+            - self.window_size
+            + 1
+        )
+
+        end_frame = self.frame_count
+
+        start_ts = self._timestamps[0]
+        end_ts = self._timestamps[-1]
+
+        prediction = None
+
+        if self.model is not None:
+
+            if hasattr(self.model, "predict"):
+
+                prediction = self.model.predict(window)
+
+            else:
+
+                logger.warning(
+                    "Model has no predict() method"
+                )
+
+        result = InferenceResult(
+            window=window,
+            start_frame_index=start_frame,
+            end_frame_index=end_frame,
+            start_timestamp=start_ts,
+            end_timestamp=end_ts,
+            prediction=prediction
+        )
+
+        self._latest_result = result
+
+        self._last_inference_frame = self.frame_count
+
+        self.total_inferences += 1
+
+        logger.debug(
+            "Inference triggered "
+            "(frames %d-%d)",
+            start_frame,
+            end_frame
+        )
+
+        return result
+
+    # ========================
+    # API helpers
+    # ========================
+
+    def get_latest_result(
+        self
+    ) -> Optional[InferenceResult]:
+
+        with self._lock:
+
+            return self._latest_result
+
+    def has_new_result(self) -> bool:
+
+        return self._latest_result is not None
+
+    def peek_next_trigger_frame(
+        self
+    ) -> Optional[int]:
         """
-        Returns the most recent temporal window on which inference was triggered.
-        This provides a clear API to retrieve valid frames regardless of the current buffer state.
-
-        Returns:
-            Optional[List[Any]]: A list of frames, or None if no inference has been triggered yet.
+        Predicts next inference frame index.
         """
-        return self._latest_inference_window
+
+        with self._lock:
+
+            if self._last_inference_frame is None:
+
+                if self.buffer.is_full():
+                    return self.frame_count
+
+                return self.window_size
+
+            return (
+                self._last_inference_frame
+                + self._stride
+            )
+
+    def get_metrics(self) -> dict:
+
+        with self._lock:
+
+            return {
+                "total_frames_processed":
+                    self.total_frames_processed,
+
+                "total_inferences":
+                    self.total_inferences,
+
+                "total_frames_skipped":
+                    self.total_frames_skipped
+            }
+
+    def reset(self):
+
+        with self._lock:
+
+            logger.info("Engine reset")
+
+            self.buffer.clear()
+
+            self.frame_count = 0
+
+            self._timestamps.clear()
+
+            self._last_inference_frame = None
+
+            self._latest_result = None
+
+            self.total_inferences = 0
+            self.total_frames_processed = 0
+            self.total_frames_skipped = 0

--- a/tests/inference/test_engine.py
+++ b/tests/inference/test_engine.py
@@ -1,67 +1,138 @@
 import pytest
-from src.inference.engine import InferenceEngine
+
+from src.inference.engine import (
+    InferenceEngine,
+    InferenceResult
+)
 
 
 class DummyModel:
-    """Mock model to test the return triggering behavior."""
     pass
 
 
-def test_inference_engine_initialization():
-    """Test if the engine initializes correctly with buffer and stride."""
-    engine = InferenceEngine(window_size=16, stride=4)
+def test_invalid_parameters():
 
-    assert engine.buffer.window_size == 16
-    assert engine.stride == 4
-    assert engine.frame_count == 0
-    assert engine.model is None
-    assert engine.get_latest_window() is None
+    with pytest.raises(ValueError):
+        InferenceEngine(window_size=0)
 
-
-def test_invalid_stride_value():
-    """Test validation for stride parameter."""
     with pytest.raises(ValueError):
         InferenceEngine(stride=0)
+
     with pytest.raises(ValueError):
-        InferenceEngine(stride=-2)
+        InferenceEngine(stride=-1)
 
 
-def test_stride_trigger_cadence():
-    """Test if inference is triggered strictly every N frames after filling the buffer."""
-    engine = InferenceEngine(window_size=3, stride=2, model=DummyModel())
+def test_first_window_triggers():
 
-    # Fill the buffer (first full window triggers inference)
+    engine = InferenceEngine(
+        window_size=3,
+        stride=2,
+        model=DummyModel()
+    )
+
     assert engine.process_frame("f1") is None
     assert engine.process_frame("f2") is None
-    assert engine.process_frame("f3") == "prediction_stub"
-    assert engine.get_latest_window() == ["f1", "f2", "f3"]
 
-    # Next frame (stride = 1 since full) -> No trigger
-    assert engine.process_frame("f4") is None
-    # Still preserves the old window!
-    assert engine.get_latest_window() == ["f1", "f2", "f3"]
+    result = engine.process_frame("f3")
 
-    # Next frame (stride = 2 since full) -> Trigger!
-    assert engine.process_frame("f5") == "prediction_stub"
-    assert engine.get_latest_window() == ["f3", "f4", "f5"]
+    assert result == "prediction_stub"
 
-    # Check if frame counter correctly reached 5
-    assert engine.frame_count == 5
+    latest = engine.get_latest_window()
+
+    assert latest == ["f1", "f2", "f3"]
 
 
-def test_get_latest_window_determinism():
-    """Verify that the retrieved window does not mutate while buffer progresses."""
-    engine = InferenceEngine(window_size=2, stride=3, model=DummyModel())
+def test_stride_cadence():
+
+    engine = InferenceEngine(
+        window_size=3,
+        stride=2,
+        model=DummyModel()
+    )
+
+    triggers = []
+
+    for i in range(10):
+
+        out = engine.process_frame(f"f{i}")
+
+        if out is not None:
+            triggers.append(i)
+
+    # Expected trigger frames:
+    # 2,4,6,8
+    assert triggers == [2, 4, 6, 8]
+
+
+def test_window_copy_safety():
+
+    engine = InferenceEngine(
+        window_size=2,
+        stride=2,
+        model=DummyModel()
+    )
 
     engine.process_frame("A")
-    engine.process_frame("B")  # Triggers inference, window is ["A", "B"]
+    engine.process_frame("B")
 
-    saved_window = engine.get_latest_window()
-    assert saved_window == ["A", "B"]
+    window = engine.get_latest_window()
 
-    engine.process_frame("C")  # No inference (stride wait)
-    engine.process_frame("D")  # No inference (stride wait)
+    window[0] = "CORRUPTED"
 
-    # Buffer has moved forward ["C", "D"], but the latest inference window should be intact
-    assert engine.buffer.get_window() == ["C", "D"]
-    assert engine.get_latest_window() == saved_window
+    assert engine.get_latest_window()[0] == "A"
+
+
+def test_metadata_integrity():
+
+    engine = InferenceEngine(
+        window_size=3,
+        stride=2,
+        model=DummyModel()
+    )
+
+    engine.process_frame("f1")
+    engine.process_frame("f2")
+    engine.process_frame("f3")
+
+    result = engine.get_latest_result()
+
+    assert isinstance(result, InferenceResult)
+
+    assert result.start_frame == 1
+    assert result.end_frame == 3
+
+
+def test_large_stride():
+
+    engine = InferenceEngine(
+        window_size=3,
+        stride=10,
+        model=DummyModel()
+    )
+
+    triggers = 0
+
+    for i in range(20):
+
+        if engine.process_frame(i):
+            triggers += 1
+
+    assert triggers == 2
+
+
+def test_reset():
+
+    engine = InferenceEngine(
+        window_size=2,
+        stride=1,
+        model=DummyModel()
+    )
+
+    engine.process_frame(1)
+    engine.process_frame(2)
+
+    engine.reset()
+
+    assert engine.frame_count == 0
+
+    assert engine.get_latest_window() is None

--- a/tests/inference/test_engine.py
+++ b/tests/inference/test_engine.py
@@ -35,11 +35,30 @@ def test_first_window_triggers():
 
     result = engine.process_frame("f3")
 
-    assert result == "prediction_stub"
+    assert isinstance(result, InferenceResult)
 
-    latest = engine.get_latest_window()
+    latest = engine.get_latest_result().window
 
-    assert latest == ["f1", "f2", "f3"]
+    assert latest == ("f1", "f2", "f3")
+
+
+def test_window_copy_safety():
+
+    engine = InferenceEngine(
+        window_size=2,
+        stride=2,
+        model=DummyModel()
+    )
+
+    engine.process_frame("A")
+    engine.process_frame("B")
+
+    window = engine.get_latest_result().window
+
+    with pytest.raises(TypeError):
+        window[0] = "CORRUPTED"
+
+    assert engine._latest_result.window[0] == "A"
 
 
 def test_stride_cadence():
@@ -59,27 +78,7 @@ def test_stride_cadence():
         if out is not None:
             triggers.append(i)
 
-    # Expected trigger frames:
-    # 2,4,6,8
     assert triggers == [2, 4, 6, 8]
-
-
-def test_window_copy_safety():
-
-    engine = InferenceEngine(
-        window_size=2,
-        stride=2,
-        model=DummyModel()
-    )
-
-    engine.process_frame("A")
-    engine.process_frame("B")
-
-    window = engine.get_latest_window()
-
-    window[0] = "CORRUPTED"
-
-    assert engine.get_latest_window()[0] == "A"
 
 
 def test_metadata_integrity():
@@ -98,8 +97,8 @@ def test_metadata_integrity():
 
     assert isinstance(result, InferenceResult)
 
-    assert result.start_frame == 1
-    assert result.end_frame == 3
+    assert result.start_frame_index == 1
+    assert result.end_frame_index == 3
 
 
 def test_large_stride():
@@ -135,4 +134,4 @@ def test_reset():
 
     assert engine.frame_count == 0
 
-    assert engine.get_latest_window() is None
+    assert engine.get_latest_result() is None

--- a/tests/inference/test_engine.py
+++ b/tests/inference/test_engine.py
@@ -7,7 +7,8 @@ from src.inference.engine import (
 
 
 class DummyModel:
-    pass
+    def __call__(self, window):
+        return window
 
 
 def test_invalid_parameters():

--- a/tests/inference/test_engine.py
+++ b/tests/inference/test_engine.py
@@ -58,7 +58,7 @@ def test_window_copy_safety():
     with pytest.raises(TypeError):
         window[0] = "CORRUPTED"
 
-    assert engine._latest_result.window[0] == "A"
+    assert engine.get_latest_result().window[0] == "A"
 
 
 def test_stride_cadence():

--- a/tests/inference/test_engine.py
+++ b/tests/inference/test_engine.py
@@ -114,7 +114,9 @@ def test_large_stride():
 
     for i in range(20):
 
-        if engine.process_frame(i):
+        out = engine.process_frame(i)
+
+        if out is not None:
             triggers += 1
 
     assert triggers == 2

--- a/tests/inference/test_engine.py
+++ b/tests/inference/test_engine.py
@@ -1,27 +1,67 @@
+import pytest
 from src.inference.engine import InferenceEngine
 
 
+class DummyModel:
+    """Mock model to test the return triggering behavior."""
+    pass
+
+
 def test_inference_engine_initialization():
-    """Test if the engine initializes correctly with the frame buffer."""
-    engine = InferenceEngine(window_size=16)
+    """Test if the engine initializes correctly with buffer and stride."""
+    engine = InferenceEngine(window_size=16, stride=4)
 
     assert engine.buffer.window_size == 16
+    assert engine.stride == 4
+    assert engine.frame_count == 0
     assert engine.model is None
+    assert engine.get_latest_window() is None
 
 
-def test_inference_engine_process_frame():
-    """Test the frame processing logic and stub prediction trigger."""
-    class DummyModel:
-        pass  # Just a placeholder for testing
+def test_invalid_stride_value():
+    """Test validation for stride parameter."""
+    with pytest.raises(ValueError):
+        InferenceEngine(stride=0)
+    with pytest.raises(ValueError):
+        InferenceEngine(stride=-2)
 
-    engine = InferenceEngine(window_size=3, model=DummyModel())
 
-    # Buffer is not full yet
-    assert engine.process_frame("frame_1") is None
-    assert engine.process_frame("frame_2") is None
+def test_stride_trigger_cadence():
+    """Test if inference is triggered strictly every N frames after filling the buffer."""
+    engine = InferenceEngine(window_size=3, stride=2, model=DummyModel())
 
-    # Buffer is now full, it should trigger inference and return the stub prediction
-    assert engine.process_frame("frame_3") == "prediction_stub"
+    # Fill the buffer (first full window triggers inference)
+    assert engine.process_frame("f1") is None
+    assert engine.process_frame("f2") is None
+    assert engine.process_frame("f3") == "prediction_stub"
+    assert engine.get_latest_window() == ["f1", "f2", "f3"]
 
-    # Next frame shifts the window (overflow), it should still predict
-    assert engine.process_frame("frame_4") == "prediction_stub"
+    # Next frame (stride = 1 since full) -> No trigger
+    assert engine.process_frame("f4") is None
+    # Still preserves the old window!
+    assert engine.get_latest_window() == ["f1", "f2", "f3"]
+
+    # Next frame (stride = 2 since full) -> Trigger!
+    assert engine.process_frame("f5") == "prediction_stub"
+    assert engine.get_latest_window() == ["f3", "f4", "f5"]
+
+    # Check if frame counter correctly reached 5
+    assert engine.frame_count == 5
+
+
+def test_get_latest_window_determinism():
+    """Verify that the retrieved window does not mutate while buffer progresses."""
+    engine = InferenceEngine(window_size=2, stride=3, model=DummyModel())
+
+    engine.process_frame("A")
+    engine.process_frame("B")  # Triggers inference, window is ["A", "B"]
+
+    saved_window = engine.get_latest_window()
+    assert saved_window == ["A", "B"]
+
+    engine.process_frame("C")  # No inference (stride wait)
+    engine.process_frame("D")  # No inference (stride wait)
+
+    # Buffer has moved forward ["C", "D"], but the latest inference window should be intact
+    assert engine.buffer.get_window() == ["C", "D"]
+    assert engine.get_latest_window() == saved_window


### PR DESCRIPTION
## Summary
Implemented configurable stride logic within the `InferenceEngine` to trigger inference every N frames instead of every frame, optimizing real-time performance.

Key additions and improvements:
* Added a `stride` parameter to `InferenceEngine` to skip non-inference frames correctly.
* Implemented deterministic windowing by returning a frozen `InferenceResult` dataclass.
* Ensured window copy safety by converting the output window to an immutable `tuple`, preventing accidental state mutation.
* Added robust frame and timestamp tracking.
* Introduced thread safety (`Lock()`) and metrics tracking.
* Updated `tests/inference/test_engine.py` to verify the expected trigger cadence, window copy safety (expecting `TypeError` on mutation), and metadata integrity.

## Linked Issue
Closes #43

## Checklist
- [x] Changes were tested locally
- [x] CI passes
- [ ] README/docs updated if relevant
- [x] Scope matches the linked Issue
- [x] No direct work outside the agreed scope