### PR TITLE
Pin gdown and use python -m invocation

### DIFF
--- a/.github/workflows/nightly-full-dataset.yml
+++ b/.github/workflows/nightly-full-dataset.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Install helpers
         run: |
           python -m pip install --upgrade pip
-          pip install gdown
+          python -m pip install gdown==5.2.1
+          python -m gdown --version
 
       - name: Prepare nightly workspace
         shell: bash
@@ -41,7 +42,7 @@ jobs:
 
       - name: Download full dataset zip from Google Drive
         run: |
-          gdown --id "${{ vars.GDRIVE_FILE_ID }}" -O "data/nightly_zip/${{ vars.FULL_DATASET_ZIP_NAME }}"
+          python -m gdown "https://drive.google.com/uc?id=${{ vars.GDRIVE_FILE_ID }}" -O "data/nightly_zip/${{ vars.FULL_DATASET_ZIP_NAME }}"
 
       - name: Unpack dataset
         run: |


### PR DESCRIPTION
## Summary
Pin `gdown` to `5.2.1` and invoke it via `python -m` to avoid CLI/PATH discrepancies in the CI workflow. Also emit `gdown --version` for verification and switch the download call to the drive `'uc?id='` URL form using the python module to ensure consistent behavior when fetching the nightly dataset zip.

## Linked Issue
Closes #61 

## Checklist
- [x] Changes were tested locally
- [x] CI passes
- [x] README/docs updated if relevant
- [x] Scope matches the linked Issue
- [x] No direct work outside the agreed scope