### PR TITLE
45 feature build sprint 2 cli to run mp4 to json action inference

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -50,7 +50,7 @@ jobs:
           docker compose run --rm \
             -e DATA_DIR=/app/data/smoke_raw \
             -e LOG_DIR=/app/data/smoke_logs \
-            inference sh -lc "python src/main.py"
+            inference sh -lc "python -m src.main"
 
       - name: Validate startup summary
         shell: bash

--- a/README.md
+++ b/README.md
@@ -29,6 +29,31 @@ mkdir data\logs
 docker compose up --build
 ```
 
+## Sprint 2 MP4 to JSON CLI
+
+Run action inference from a single MP4 file and write a JSON event log:
+
+```powershell
+python -m src.main `
+  --input data\raw\walking\sample.mp4 `
+  --checkpoint data\logs\checkpoints\baseline_epoch_10.pth `
+  --config configs\data_pipeline.yml `
+  --output data\logs\actions.json
+```
+
+Run the same flow in Docker:
+
+```bash
+docker compose run --rm inference python -m src.main \
+  --input /app/data/raw/walking/sample.mp4 \
+  --checkpoint /app/data/logs/checkpoints/baseline_epoch_10.pth \
+  --config /app/configs/data_pipeline.yml \
+  --output /app/data/logs/actions.json
+```
+
+Inference mode requires `--input` and `--checkpoint` together. Without these arguments,
+`src.main` keeps the startup summary behavior and writes `startup_summary.json`.
+
 ## Documentation
 - [Data Pipeline](docs/data-pipeline.md)
 - [Inference](docs/inference.md)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ python -m src.main `
   --input data\raw\walking\sample.mp4 `
   --checkpoint data\logs\checkpoints\baseline_epoch_10.pth `
   --config configs\data_pipeline.yml `
-  --output data\logs\actions.json
+  --output data\logs\actions.json `
+  --device auto
 ```
 
 Run the same flow in Docker:

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,6 +15,6 @@ services:
       - ./data/logs:/app/data/logs
 
 
-    command: [ "sh", "-lc", "python src/main.py && tail -f /dev/null" ]
+    command: [ "sh", "-lc", "python -m src.main && tail -f /dev/null" ]
     stdin_open: true
     tty: true

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,6 +15,6 @@ services:
       - ./data/logs:/app/data/logs
 
 
-    command: [ "sh", "-lc", "python -m src.main && tail -f /dev/null" ]
+    command: [ "sh", "-lc", "python src/main.py && tail -f /dev/null" ]
     stdin_open: true
     tty: true

--- a/configs/data_pipeline.yml
+++ b/configs/data_pipeline.yml
@@ -10,7 +10,12 @@ pipeline:
 
 inference:
   stride: 1
-  class_labels: []
+  class_labels:
+    - car_drops_off_person
+    - car_makes_u_turn
+    - motorcycle_makes_u_turn
+    - motorcycle_turns_right
+    - person_sits_down
 
 tracking:
   default_track_id: null

--- a/configs/data_pipeline.yml
+++ b/configs/data_pipeline.yml
@@ -8,6 +8,13 @@ pipeline:
   target_resolution: [224, 224]
   temporal_window: 16              
 
+inference:
+  stride: 1
+  class_labels: []
+
+tracking:
+  default_track_id: null
+
 splits:
   train: 0.7
   val: 0.15

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -18,4 +18,4 @@ RUN pip install --no-cache-dir -r requirements-dev.txt
 
 COPY src/ /app/src/
 
-CMD ["python", "-m", "src.main"]
+CMD ["python", "src/main.py"]

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -18,4 +18,4 @@ RUN pip install --no-cache-dir -r requirements-dev.txt
 
 COPY src/ /app/src/
 
-CMD ["python", "src/main.py"]
+CMD ["python", "-m", "src.main"]

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -12,7 +12,8 @@ python -m src.main `
   --input data\raw\walking\sample.mp4 `
   --checkpoint data\logs\checkpoints\baseline_epoch_10.pth `
   --config configs\data_pipeline.yml `
-  --output data\logs\actions.json
+  --output data\logs\actions.json `
+  --device auto
 ```
 
 ### Arguments
@@ -23,6 +24,7 @@ python -m src.main `
 | `--checkpoint` | Yes (in inference mode) | Model checkpoint (`.pth`) |
 | `--config` | No | YAML config with runtime options (default: `configs/data_pipeline.yml`) |
 | `--output` | No | JSON output path (default: `data/logs/actions.json`) |
+| `--device` | No | Device override: `auto`, `cpu`, `cuda`, `mps` (CLI override has priority over config) |
 
 `--input` and `--checkpoint` must be provided together.
 If neither is provided, `src.main` runs startup summary mode.
@@ -46,12 +48,18 @@ pipeline:
 inference:
   stride: 1
   class_labels: []  # optional list of labels by class index
+  device: auto      # optional: auto/cpu/cuda/mps
 
 tracking:
   default_track_id: null  # optional integer
 ```
 
 If `tracking.default_track_id` is set, that track ID is attached to every emitted event.
+
+Device resolution order:
+1. `--device` (CLI override)
+2. `inference.device` in YAML config
+3. automatic fallback: `cuda` -> `mps` -> `cpu`
 
 ## Checkpoint metadata requirements
 

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -52,3 +52,12 @@ tracking:
 ```
 
 If `tracking.default_track_id` is set, that track ID is attached to every emitted event.
+
+## Checkpoint metadata requirements
+
+Inference expects checkpoint metadata fields:
+- `model_name` (supported: `baseline`, `dummy`)
+- `num_classes` (positive integer)
+- `model_state_dict`
+
+The loader uses `num_classes` from metadata and does not infer class count from specific layer names (for example `fc`, `head`, or `classifier`).

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -3,6 +3,52 @@
 
 [Back to README](../README.md)
 
-This file is the module documentation template for Inference.
-This section should later describe buffering, stride, windowing, inference flow, and tests.
-For now, it is a placeholder waiting for the module owner to complete it.
+## Sprint 2 CLI: MP4 to JSON
+
+The Sprint 2 milestone is exposed through `src.main` inference mode:
+
+```powershell
+python -m src.main `
+  --input data\raw\walking\sample.mp4 `
+  --checkpoint data\logs\checkpoints\baseline_epoch_10.pth `
+  --config configs\data_pipeline.yml `
+  --output data\logs\actions.json
+```
+
+### Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--input` | Yes (in inference mode) | Input `.mp4` path |
+| `--checkpoint` | Yes (in inference mode) | Model checkpoint (`.pth`) |
+| `--config` | No | YAML config with runtime options (default: `configs/data_pipeline.yml`) |
+| `--output` | No | JSON output path (default: `data/logs/actions.json`) |
+
+`--input` and `--checkpoint` must be provided together.
+If neither is provided, `src.main` runs startup summary mode.
+
+## Runtime flow
+
+1. Load YAML settings (`pipeline`, optional `inference`, optional `tracking`).
+2. Load model checkpoint.
+3. Read MP4 frames with offline runtime.
+4. Run `InferenceEngine` windows through model + tensorizer adapter.
+5. Convert `InferenceResult` objects to `ActionEvent` records.
+6. Save action log JSON with `ActionEventWriter`.
+
+## Supported config keys
+
+```yaml
+pipeline:
+  target_resolution: [224, 224]
+  temporal_window: 16
+
+inference:
+  stride: 1
+  class_labels: []  # optional list of labels by class index
+
+tracking:
+  default_track_id: null  # optional integer
+```
+
+If `tracking.default_track_id` is set, that track ID is attached to every emitted event.

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -7,14 +7,36 @@
 
 The Sprint 2 milestone is exposed through `src.main` inference mode:
 
-```powershell
-python -m src.main `
-  --input data\raw\walking\sample.mp4 `
-  --checkpoint data\logs\checkpoints\baseline_epoch_10.pth `
-  --config configs\data_pipeline.yml `
-  --output data\logs\actions.json `
+
+(the commands below are for bash, below commands are for bash on Windows, if you are using Powershel, remove 'MSYS_NO_PATHCONV=1')
+
+Run in this order:
+```
+MSYS_NO_PATHCONV=1 docker compose run --rm inference python -m src.data.sample --config /app/configs/data_pipeline.yml --output manifest.jsonl
+```
+
+If the first step prints "No videos found", it means that there is no data in the data/raw on the host and it needs to be placed there first.
+
+Check if the file has been created:
+```
+MSYS_NO_PATHCONV=1 docker compose run --rm inference sh -lc "ls -l /app/data/manifests/manifest.jsonl"
+```
+
+Then training:
+```
+MSYS_NO_PATHCONV=1 docker compose run --rm inference python -m scripts.train
+```
+
+At the end, the inference:
+```
+MSYS_NO_PATHCONV=1 docker compose run --rm inference python -m src.main \
+  --input /app/data/raw/walking/sample.mp4 \
+  --checkpoint /app/data/logs/checkpoints/baseline_epoch_10.pth \
+  --config /app/configs/data_pipeline.yml \
+  --output /app/data/logs/actions.json \
   --device auto
 ```
+
 
 ### Arguments
 

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -5,33 +5,11 @@
 
 ## Sprint 2 CLI: MP4 to JSON
 
-The Sprint 2 milestone is exposed through `src.main` inference mode:
-
-
-(the commands below are for bash, below commands are for bash on Windows, if you are using Powershel, remove 'MSYS_NO_PATHCONV=1')
-
-Run in this order:
+To run in inference mode:
 ```
-MSYS_NO_PATHCONV=1 docker compose run --rm inference python -m src.data.sample --config /app/configs/data_pipeline.yml --output manifest.jsonl
-```
-
-If the first step prints "No videos found", it means that there is no data in the data/raw on the host and it needs to be placed there first.
-
-Check if the file has been created:
-```
-MSYS_NO_PATHCONV=1 docker compose run --rm inference sh -lc "ls -l /app/data/manifests/manifest.jsonl"
-```
-
-Then training:
-```
-MSYS_NO_PATHCONV=1 docker compose run --rm inference python -m scripts.train
-```
-
-At the end, the inference:
-```
-MSYS_NO_PATHCONV=1 docker compose run --rm inference python -m src.main \
-  --input /app/data/raw/walking/sample.mp4 \
-  --checkpoint /app/data/logs/checkpoints/baseline_epoch_10.pth \
+docker compose run --rm inference python -m src.main \
+  --input /app/data/raw/car_drops_off_person/0BD540FB-26D7-4814-8229-5572B9132328-306-00000008A9AAB259_1.mp4 \
+  --checkpoint /app/data/logs/checkpoints/baseline_epoch_50.pth \
   --config /app/configs/data_pipeline.yml \
   --output /app/data/logs/actions.json \
   --device auto
@@ -87,7 +65,4 @@ Device resolution order:
 
 Inference expects checkpoint metadata fields:
 - `model_name` (supported: `baseline`, `dummy`)
-- `num_classes` (positive integer)
 - `model_state_dict`
-
-The loader uses `num_classes` from metadata and does not infer class count from specific layer names (for example `fc`, `head`, or `classifier`).

--- a/docs/ml-baseline.md
+++ b/docs/ml-baseline.md
@@ -18,7 +18,6 @@ docker compose run --rm inference python -m scripts.train
 
 Saved checkpoints include metadata required by inference:
 - `model_name: baseline`
-- `num_classes`
 - `model_state_dict`
 
 **Class Configuration:**

--- a/docs/ml-baseline.md
+++ b/docs/ml-baseline.md
@@ -16,6 +16,11 @@ docker compose run --rm inference python -m scripts.train
 * **Model checkpoints:** Saved to `./data/logs/checkpoints/`.
 * **Training metrics:** Performance logs (JSONL) are saved to `./data/logs/metrics/`.
 
+Saved checkpoints include metadata required by inference:
+- `model_name: baseline`
+- `num_classes`
+- `model_state_dict`
+
 **Class Configuration:**
 The `num_classes` parameter is intentionally derived dynamically from the dataset manifest during runtime. This approach ensures that the model architecture (specifically the final linear layer) always matches the number of unique labels present in the current data subset, avoiding configuration drift and manual errors.
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -104,6 +104,8 @@ def main() -> int:
     checkpoints_path = checkpoints_dir / f'baseline_epoch_{epochs}.pth'
     torch.save({
         'epoch': epochs,
+        'model_name': 'baseline',
+        'num_classes': num_classes,
         'model_state_dict': model.state_dict(),
         'optimizer_state_dict': optimizer.state_dict(),
         'loss': avg_loss,

--- a/src/inference/mp4_cli.py
+++ b/src/inference/mp4_cli.py
@@ -23,6 +23,7 @@ class InferenceCliRequest:
     checkpoint_path: Path
     config_path: Path
     output_path: Path
+    device: str | None = None
 
 
 @dataclass(frozen=True)
@@ -34,6 +35,7 @@ class InferenceRuntimeSettings:
     stride: int
     class_labels: list[str]
     default_track_id: int | None
+    device: str | None
 
 
 class WindowModelAdapter:
@@ -92,8 +94,10 @@ def run_mp4_to_json_action_inference(request: InferenceCliRequest) -> int:
         raise ValueError("input_path must point to an .mp4 file")
 
     settings = load_runtime_settings(request.config_path)
-    device = torch.device("cuda" if torch.cuda.is_available()
-                          else "cpu")  # it ignores mac
+    device = resolve_inference_device(
+        cli_device=request.device,
+        config_device=settings.device,
+    )
     model = load_model_from_checkpoint(request.checkpoint_path, device)
 
     tensorizer = FrameTensorizer(target_resolution=settings.target_resolution)
@@ -160,6 +164,7 @@ def load_runtime_settings(config_path: Path) -> InferenceRuntimeSettings:
     class_labels = _parse_class_labels(inference_cfg.get("class_labels"))
     default_track_id = _parse_optional_track_id(
         tracking_cfg.get("default_track_id"))
+    device = _parse_optional_device(inference_cfg.get("device"), "inference.device")
 
     return InferenceRuntimeSettings(
         target_resolution=target_resolution,
@@ -167,6 +172,7 @@ def load_runtime_settings(config_path: Path) -> InferenceRuntimeSettings:
         stride=stride,
         class_labels=class_labels,
         default_track_id=default_track_id,
+        device=device,
     )
 
 
@@ -291,6 +297,8 @@ def _validate_request_paths(request: InferenceCliRequest) -> None:
         raise TypeError("request.config_path must be a pathlib.Path instance")
     if not isinstance(request.output_path, Path):
         raise TypeError("request.output_path must be a pathlib.Path instance")
+    if request.device is not None and not isinstance(request.device, str):
+        raise TypeError("request.device must be a string or None")
 
 
 def _parse_positive_int(value: object, field_name: str) -> int:
@@ -343,6 +351,62 @@ def _parse_optional_track_id(value: object) -> int | None:
     if value < 0:
         raise ValueError("tracking.default_track_id must be >= 0")
     return value
+
+
+def _parse_optional_device(value: object, field_name: str) -> str | None:
+    """Parse optional inference device override."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be one of: auto, cpu, cuda, mps")
+    normalized = value.strip().lower()
+    if normalized not in {"auto", "cpu", "cuda", "mps"}:
+        raise ValueError(f"{field_name} must be one of: auto, cpu, cuda, mps")
+    return normalized
+
+
+def resolve_inference_device(
+    cli_device: str | None,
+    config_device: str | None,
+) -> torch.device:
+    """Resolve torch device from CLI/config overrides and available backends."""
+    cli_choice = _parse_optional_device(cli_device, "request.device")
+    config_choice = _parse_optional_device(config_device, "inference.device")
+    preferred_device = cli_choice if cli_choice is not None else config_choice
+
+    if preferred_device in {None, "auto"}:
+        if torch.cuda.is_available():
+            return torch.device("cuda")
+        if _is_mps_available():
+            return torch.device("mps")
+        return torch.device("cpu")
+
+    if preferred_device == "cpu":
+        return torch.device("cpu")
+
+    if preferred_device == "cuda":
+        if not torch.cuda.is_available():
+            raise ValueError(
+                "CUDA device requested but not available on this machine",
+            )
+        return torch.device("cuda")
+
+    if preferred_device == "mps":
+        if not _is_mps_available():
+            raise ValueError(
+                "MPS device requested but not available on this machine",
+            )
+        return torch.device("mps")
+
+    raise ValueError(f"Unsupported device selection: {preferred_device}")
+
+
+def _is_mps_available() -> bool:
+    """Return True when torch MPS backend is available."""
+    mps_backend = getattr(torch.backends, "mps", None)
+    if mps_backend is None or not hasattr(mps_backend, "is_available"):
+        return False
+    return bool(mps_backend.is_available())
 
 
 def _validate_state_dict(value: object) -> dict[str, torch.Tensor]:

--- a/src/inference/mp4_cli.py
+++ b/src/inference/mp4_cli.py
@@ -1,6 +1,7 @@
 """MP4-to-JSON action inference CLI helpers."""
 
 from dataclasses import dataclass
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -13,6 +14,8 @@ from src.inference.offline_runtime import run_video
 from src.inference.tensorize import FrameTensorizer
 from src.models.baseline import BaselineBehaviorModel
 from src.models.dummy import DummyBehaviorModel
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -120,9 +123,11 @@ def run_mp4_to_json_action_inference(request: InferenceCliRequest) -> int:
 
     request.output_path.parent.mkdir(parents=True, exist_ok=True)
     writer.save(str(request.output_path))
-    # change to log
-    print(
-        f"[OK] Wrote {len(writer.get_log().events)} action events to: {request.output_path}")
+    logger.info(
+        "[OK] Wrote %d action events to: %s",
+        len(writer.get_log().events),
+        request.output_path,
+    )
 
     return 0
 

--- a/src/inference/mp4_cli.py
+++ b/src/inference/mp4_cli.py
@@ -76,7 +76,8 @@ class WindowModelAdapter:
 
         if output.ndim == 2:
             if output.shape[0] < 1:
-                raise ValueError("model output batch dimension must not be empty")
+                raise ValueError(
+                    "model output batch dimension must not be empty")
             return output[0].detach().cpu()
 
         raise ValueError("model output tensor must be 1D or 2D")
@@ -95,7 +96,10 @@ def run_mp4_to_json_action_inference(request: InferenceCliRequest) -> int:
     model = load_model_from_checkpoint(request.checkpoint_path, device)
 
     tensorizer = FrameTensorizer(target_resolution=settings.target_resolution)
-    model_adapter = WindowModelAdapter(model=model, tensorizer=tensorizer, device=device)
+    model_adapter = WindowModelAdapter(
+        model=model, tensorizer=tensorizer, device=device)
+
+    # initializing of engine in this place is more flexible than in the run_video()
     engine = InferenceEngine(
         window_size=settings.window_size,
         stride=settings.stride,
@@ -110,7 +114,8 @@ def run_mp4_to_json_action_inference(request: InferenceCliRequest) -> int:
 
     request.output_path.parent.mkdir(parents=True, exist_ok=True)
     writer.save(str(request.output_path))
-    print(f"[OK] Wrote {len(writer.get_log().events)} action events to: {request.output_path}")
+    print(
+        f"[OK] Wrote {len(writer.get_log().events)} action events to: {request.output_path}")
 
     return 0
 
@@ -122,6 +127,7 @@ def load_runtime_settings(config_path: Path) -> InferenceRuntimeSettings:
     if not config_path.exists():
         raise FileNotFoundError(f"Config file not found: {config_path}")
     if not config_path.is_file():
+        # found but it is not a file
         raise ValueError(f"Config path must point to a file: {config_path}")
 
     with config_path.open("r", encoding="utf-8") as config_file:
@@ -133,7 +139,8 @@ def load_runtime_settings(config_path: Path) -> InferenceRuntimeSettings:
         raise TypeError("Config root must be a mapping/object")
 
     pipeline_cfg = _ensure_mapping(raw_config.get("pipeline", {}), "pipeline")
-    inference_cfg = _ensure_mapping(raw_config.get("inference", {}), "inference")
+    inference_cfg = _ensure_mapping(
+        raw_config.get("inference", {}), "inference")
     tracking_cfg = _ensure_mapping(raw_config.get("tracking", {}), "tracking")
 
     target_resolution = _parse_target_resolution(
@@ -148,7 +155,8 @@ def load_runtime_settings(config_path: Path) -> InferenceRuntimeSettings:
         "inference.stride",
     )
     class_labels = _parse_class_labels(inference_cfg.get("class_labels"))
-    default_track_id = _parse_optional_track_id(tracking_cfg.get("default_track_id"))
+    default_track_id = _parse_optional_track_id(
+        tracking_cfg.get("default_track_id"))
 
     return InferenceRuntimeSettings(
         target_resolution=target_resolution,
@@ -169,9 +177,11 @@ def load_model_from_checkpoint(
     if not isinstance(device, torch.device):
         raise TypeError("device must be a torch.device instance")
     if not checkpoint_path.exists():
-        raise FileNotFoundError(f"Checkpoint file not found: {checkpoint_path}")
+        raise FileNotFoundError(
+            f"Checkpoint file not found: {checkpoint_path}")
     if not checkpoint_path.is_file():
-        raise ValueError(f"Checkpoint path must point to a file: {checkpoint_path}")
+        raise ValueError(
+            f"Checkpoint path must point to a file: {checkpoint_path}")
 
     raw_checkpoint = torch.load(str(checkpoint_path), map_location=device)
     if not isinstance(raw_checkpoint, dict):
@@ -183,7 +193,8 @@ def load_model_from_checkpoint(
 
     model_name = raw_checkpoint.get("model_name")
     if model_name is not None and not isinstance(model_name, str):
-        raise TypeError("model_name in checkpoint must be a string when provided")
+        raise TypeError(
+            "model_name in checkpoint must be a string when provided")
 
     candidates = _resolve_model_candidates(model_name)
     errors: list[str] = []
@@ -214,7 +225,8 @@ def build_track_ids(
     if not isinstance(results, list):
         raise TypeError("results must be a list of InferenceResult objects")
     if default_track_id is not None and (
-        not isinstance(default_track_id, int) or isinstance(default_track_id, bool)
+        not isinstance(default_track_id, int) or isinstance(
+            default_track_id, bool)
     ):
         raise TypeError("default_track_id must be an integer or None")
     if isinstance(default_track_id, int) and default_track_id < 0:
@@ -222,7 +234,8 @@ def build_track_ids(
 
     for result in results:
         if not isinstance(result, InferenceResult):
-            raise TypeError("results must only contain InferenceResult objects")
+            raise TypeError(
+                "results must only contain InferenceResult objects")
 
     if default_track_id is None:
         return [None] * len(results)
@@ -241,7 +254,8 @@ def _validate_request_paths(request: InferenceCliRequest) -> None:
     if not isinstance(request.input_path, Path):
         raise TypeError("request.input_path must be a pathlib.Path instance")
     if not isinstance(request.checkpoint_path, Path):
-        raise TypeError("request.checkpoint_path must be a pathlib.Path instance")
+        raise TypeError(
+            "request.checkpoint_path must be a pathlib.Path instance")
     if not isinstance(request.config_path, Path):
         raise TypeError("request.config_path must be a pathlib.Path instance")
     if not isinstance(request.output_path, Path):
@@ -250,7 +264,7 @@ def _validate_request_paths(request: InferenceCliRequest) -> None:
 
 def _parse_positive_int(value: object, field_name: str) -> int:
     """Parse a positive integer while rejecting booleans."""
-    if not isinstance(value, int) or isinstance(value, bool):
+    if not isinstance(value, int) or isinstance(value, bool):  # bool inherit from int
         raise TypeError(f"{field_name} must be an integer")
     if value <= 0:
         raise ValueError(f"{field_name} must be > 0")
@@ -260,9 +274,11 @@ def _parse_positive_int(value: object, field_name: str) -> int:
 def _parse_target_resolution(value: object) -> tuple[int, int]:
     """Parse and validate target resolution as (width, height)."""
     if not isinstance(value, (list, tuple)):
-        raise TypeError("pipeline.target_resolution must be a list/tuple of two integers")
+        raise TypeError(
+            "pipeline.target_resolution must be a list/tuple of two integers")
     if len(value) != 2:
-        raise ValueError("pipeline.target_resolution must contain exactly 2 values")
+        raise ValueError(
+            "pipeline.target_resolution must contain exactly 2 values")
 
     width = _parse_positive_int(value[0], "pipeline.target_resolution[0]")
     height = _parse_positive_int(value[1], "pipeline.target_resolution[1]")
@@ -281,7 +297,8 @@ def _parse_class_labels(value: object) -> list[str]:
         if not isinstance(label, str):
             raise TypeError("inference.class_labels must contain only strings")
         if not label.strip():
-            raise ValueError("inference.class_labels must not contain empty strings")
+            raise ValueError(
+                "inference.class_labels must not contain empty strings")
         class_labels.append(label)
     return class_labels
 
@@ -309,7 +326,8 @@ def _validate_state_dict(value: object) -> dict[str, torch.Tensor]:
         if not isinstance(key, str):
             raise TypeError("model_state_dict keys must be strings")
         if not isinstance(tensor, torch.Tensor):
-            raise TypeError("model_state_dict values must be torch.Tensor objects")
+            raise TypeError(
+                "model_state_dict values must be torch.Tensor objects")
         normalized[key] = tensor
     return normalized
 

--- a/src/inference/mp4_cli.py
+++ b/src/inference/mp4_cli.py
@@ -1,0 +1,353 @@
+"""MP4-to-JSON action inference CLI helpers."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+import yaml
+
+from src.inference.engine import InferenceEngine, InferenceResult
+from src.inference.json_writer import ActionEventWriter
+from src.inference.offline_runtime import run_video
+from src.inference.tensorize import FrameTensorizer
+from src.models.baseline import BaselineBehaviorModel
+from src.models.dummy import DummyBehaviorModel
+
+
+@dataclass(frozen=True)
+class InferenceCliRequest:
+    """Input contract for MP4-to-JSON action inference."""
+
+    input_path: Path
+    checkpoint_path: Path
+    config_path: Path
+    output_path: Path
+
+
+@dataclass(frozen=True)
+class InferenceRuntimeSettings:
+    """Typed runtime settings parsed from YAML config."""
+
+    target_resolution: tuple[int, int]
+    window_size: int
+    stride: int
+    class_labels: list[str]
+    default_track_id: int | None
+
+
+class WindowModelAdapter:
+    """Adapter that tensorizes frame windows before calling a torch model."""
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        tensorizer: FrameTensorizer,
+        device: torch.device,
+    ) -> None:
+        """Initialize the adapter with a model, tensorizer, and target device."""
+        if not isinstance(model, torch.nn.Module):
+            raise TypeError("model must be a torch.nn.Module instance")
+        if not isinstance(tensorizer, FrameTensorizer):
+            raise TypeError("tensorizer must be a FrameTensorizer instance")
+        if not isinstance(device, torch.device):
+            raise TypeError("device must be a torch.device instance")
+
+        self._model = model
+        self._tensorizer = tensorizer
+        self._device = device
+
+    def __call__(self, window: tuple[Any, ...]) -> torch.Tensor:
+        """Run model inference on a frame window and return logits/probabilities."""
+        if not isinstance(window, tuple):
+            raise TypeError("window must be a tuple of frames")
+        if len(window) == 0:
+            raise ValueError("window cannot be empty")
+
+        tensor = self._tensorizer.tensorize(list(window)).to(self._device)
+        with torch.no_grad():
+            output = self._model(tensor)
+
+        if not isinstance(output, torch.Tensor):
+            raise TypeError("model output must be a torch.Tensor")
+
+        if output.ndim == 1:
+            return output.detach().cpu()
+
+        if output.ndim == 2:
+            if output.shape[0] < 1:
+                raise ValueError("model output batch dimension must not be empty")
+            return output[0].detach().cpu()
+
+        raise ValueError("model output tensor must be 1D or 2D")
+
+
+def run_mp4_to_json_action_inference(request: InferenceCliRequest) -> int:
+    """Run end-to-end MP4 inference and save ActionEvent log as JSON."""
+    if not isinstance(request, InferenceCliRequest):
+        raise TypeError("request must be an InferenceCliRequest instance")
+    _validate_request_paths(request)
+    if request.input_path.suffix.lower() != ".mp4":
+        raise ValueError("input_path must point to an .mp4 file")
+
+    settings = load_runtime_settings(request.config_path)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = load_model_from_checkpoint(request.checkpoint_path, device)
+
+    tensorizer = FrameTensorizer(target_resolution=settings.target_resolution)
+    model_adapter = WindowModelAdapter(model=model, tensorizer=tensorizer, device=device)
+    engine = InferenceEngine(
+        window_size=settings.window_size,
+        stride=settings.stride,
+        model=model_adapter,
+    )
+
+    _, _, inference_results = run_video(str(request.input_path), engine=engine)
+    track_ids = build_track_ids(inference_results, settings.default_track_id)
+
+    writer = ActionEventWriter(class_labels=settings.class_labels)
+    writer.add_results(inference_results, track_ids=track_ids)
+
+    request.output_path.parent.mkdir(parents=True, exist_ok=True)
+    writer.save(str(request.output_path))
+    print(f"[OK] Wrote {len(writer.get_log().events)} action events to: {request.output_path}")
+
+    return 0
+
+
+def load_runtime_settings(config_path: Path) -> InferenceRuntimeSettings:
+    """Load and validate inference runtime settings from YAML config."""
+    if not isinstance(config_path, Path):
+        raise TypeError("config_path must be a pathlib.Path instance")
+    if not config_path.exists():
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+    if not config_path.is_file():
+        raise ValueError(f"Config path must point to a file: {config_path}")
+
+    with config_path.open("r", encoding="utf-8") as config_file:
+        raw_config = yaml.safe_load(config_file)
+
+    if raw_config is None:
+        raw_config = {}
+    if not isinstance(raw_config, dict):
+        raise TypeError("Config root must be a mapping/object")
+
+    pipeline_cfg = _ensure_mapping(raw_config.get("pipeline", {}), "pipeline")
+    inference_cfg = _ensure_mapping(raw_config.get("inference", {}), "inference")
+    tracking_cfg = _ensure_mapping(raw_config.get("tracking", {}), "tracking")
+
+    target_resolution = _parse_target_resolution(
+        pipeline_cfg.get("target_resolution", (224, 224)),
+    )
+    window_size = _parse_positive_int(
+        pipeline_cfg.get("temporal_window", 16),
+        "pipeline.temporal_window",
+    )
+    stride = _parse_positive_int(
+        inference_cfg.get("stride", 1),
+        "inference.stride",
+    )
+    class_labels = _parse_class_labels(inference_cfg.get("class_labels"))
+    default_track_id = _parse_optional_track_id(tracking_cfg.get("default_track_id"))
+
+    return InferenceRuntimeSettings(
+        target_resolution=target_resolution,
+        window_size=window_size,
+        stride=stride,
+        class_labels=class_labels,
+        default_track_id=default_track_id,
+    )
+
+
+def load_model_from_checkpoint(
+    checkpoint_path: Path,
+    device: torch.device,
+) -> torch.nn.Module:
+    """Load a model from checkpoint and move it to the target device."""
+    if not isinstance(checkpoint_path, Path):
+        raise TypeError("checkpoint_path must be a pathlib.Path instance")
+    if not isinstance(device, torch.device):
+        raise TypeError("device must be a torch.device instance")
+    if not checkpoint_path.exists():
+        raise FileNotFoundError(f"Checkpoint file not found: {checkpoint_path}")
+    if not checkpoint_path.is_file():
+        raise ValueError(f"Checkpoint path must point to a file: {checkpoint_path}")
+
+    raw_checkpoint = torch.load(str(checkpoint_path), map_location=device)
+    if not isinstance(raw_checkpoint, dict):
+        raise TypeError("Checkpoint must contain a mapping/object payload")
+
+    raw_state_dict = raw_checkpoint.get("model_state_dict", raw_checkpoint)
+    state_dict = _validate_state_dict(raw_state_dict)
+    num_classes = _infer_num_classes(state_dict)
+
+    model_name = raw_checkpoint.get("model_name")
+    if model_name is not None and not isinstance(model_name, str):
+        raise TypeError("model_name in checkpoint must be a string when provided")
+
+    candidates = _resolve_model_candidates(model_name)
+    errors: list[str] = []
+    for candidate in candidates:
+        model = _build_model(candidate, num_classes)
+        try:
+            model.load_state_dict(state_dict, strict=True)
+        except RuntimeError as runtime_error:
+            errors.append(f"{candidate}: {runtime_error}")
+            continue
+
+        model.to(device)
+        model.eval()
+        return model
+
+    joined_errors = "; ".join(errors)
+    raise ValueError(
+        "Could not load checkpoint into a supported model architecture. "
+        f"Attempted: {', '.join(candidates)}. Details: {joined_errors}",
+    )
+
+
+def build_track_ids(
+    results: list[InferenceResult],
+    default_track_id: int | None,
+) -> list[int | None]:
+    """Build per-result tracking IDs used by ActionEventWriter."""
+    if not isinstance(results, list):
+        raise TypeError("results must be a list of InferenceResult objects")
+    if default_track_id is not None and (
+        not isinstance(default_track_id, int) or isinstance(default_track_id, bool)
+    ):
+        raise TypeError("default_track_id must be an integer or None")
+    if isinstance(default_track_id, int) and default_track_id < 0:
+        raise ValueError("default_track_id must be >= 0")
+
+    for result in results:
+        if not isinstance(result, InferenceResult):
+            raise TypeError("results must only contain InferenceResult objects")
+
+    if default_track_id is None:
+        return [None] * len(results)
+    return [default_track_id] * len(results)
+
+
+def _ensure_mapping(value: object, field_name: str) -> dict[str, Any]:
+    """Ensure value is a dictionary-like mapping represented as dict."""
+    if not isinstance(value, dict):
+        raise TypeError(f"{field_name} must be a mapping/object")
+    return value
+
+
+def _validate_request_paths(request: InferenceCliRequest) -> None:
+    """Validate that request fields are Path objects."""
+    if not isinstance(request.input_path, Path):
+        raise TypeError("request.input_path must be a pathlib.Path instance")
+    if not isinstance(request.checkpoint_path, Path):
+        raise TypeError("request.checkpoint_path must be a pathlib.Path instance")
+    if not isinstance(request.config_path, Path):
+        raise TypeError("request.config_path must be a pathlib.Path instance")
+    if not isinstance(request.output_path, Path):
+        raise TypeError("request.output_path must be a pathlib.Path instance")
+
+
+def _parse_positive_int(value: object, field_name: str) -> int:
+    """Parse a positive integer while rejecting booleans."""
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError(f"{field_name} must be an integer")
+    if value <= 0:
+        raise ValueError(f"{field_name} must be > 0")
+    return value
+
+
+def _parse_target_resolution(value: object) -> tuple[int, int]:
+    """Parse and validate target resolution as (width, height)."""
+    if not isinstance(value, (list, tuple)):
+        raise TypeError("pipeline.target_resolution must be a list/tuple of two integers")
+    if len(value) != 2:
+        raise ValueError("pipeline.target_resolution must contain exactly 2 values")
+
+    width = _parse_positive_int(value[0], "pipeline.target_resolution[0]")
+    height = _parse_positive_int(value[1], "pipeline.target_resolution[1]")
+    return (width, height)
+
+
+def _parse_class_labels(value: object) -> list[str]:
+    """Parse optional class labels list."""
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise TypeError("inference.class_labels must be a list of strings")
+
+    class_labels: list[str] = []
+    for label in value:
+        if not isinstance(label, str):
+            raise TypeError("inference.class_labels must contain only strings")
+        if not label.strip():
+            raise ValueError("inference.class_labels must not contain empty strings")
+        class_labels.append(label)
+    return class_labels
+
+
+def _parse_optional_track_id(value: object) -> int | None:
+    """Parse optional default track ID."""
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError("tracking.default_track_id must be an integer or null")
+    if value < 0:
+        raise ValueError("tracking.default_track_id must be >= 0")
+    return value
+
+
+def _validate_state_dict(value: object) -> dict[str, torch.Tensor]:
+    """Validate and normalize checkpoint state_dict."""
+    if not isinstance(value, dict):
+        raise TypeError("model_state_dict must be a mapping/object")
+    if len(value) == 0:
+        raise ValueError("model_state_dict must not be empty")
+
+    normalized: dict[str, torch.Tensor] = {}
+    for key, tensor in value.items():
+        if not isinstance(key, str):
+            raise TypeError("model_state_dict keys must be strings")
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError("model_state_dict values must be torch.Tensor objects")
+        normalized[key] = tensor
+    return normalized
+
+
+def _infer_num_classes(state_dict: dict[str, torch.Tensor]) -> int:
+    """Infer output class count from fc.weight shape."""
+    key_candidates = ("model.fc.weight", "fc.weight")
+    for key in key_candidates:
+        maybe_weight = state_dict.get(key)
+        if maybe_weight is None:
+            continue
+        if not isinstance(maybe_weight, torch.Tensor):
+            raise TypeError(f"{key} must be a torch.Tensor")
+        if maybe_weight.ndim != 2:
+            raise ValueError(f"{key} must be a rank-2 tensor")
+        return int(maybe_weight.shape[0])
+
+    raise ValueError(
+        "Could not infer number of classes from checkpoint. "
+        "Expected key 'model.fc.weight' or 'fc.weight'.",
+    )
+
+
+def _resolve_model_candidates(model_name: str | None) -> list[str]:
+    """Resolve model loading order from optional model_name metadata."""
+    if model_name is None:
+        return ["baseline", "dummy"]
+
+    normalized_name = model_name.strip().lower()
+    if normalized_name not in {"baseline", "dummy"}:
+        raise ValueError("model_name must be either 'baseline' or 'dummy'")
+    return [normalized_name]
+
+
+def _build_model(model_name: str, num_classes: int) -> torch.nn.Module:
+    """Build a supported model instance by name."""
+    if model_name == "baseline":
+        return BaselineBehaviorModel(num_classes=num_classes)
+    if model_name == "dummy":
+        return DummyBehaviorModel(num_classes=num_classes)
+    raise ValueError(f"Unsupported model name: {model_name}")

--- a/src/inference/mp4_cli.py
+++ b/src/inference/mp4_cli.py
@@ -46,13 +46,15 @@ class WindowModelAdapter:
 
     def __init__(
         self,
-        model: torch.nn.Module,  # is model based on torch.nn.Module?
+        model: Any,
         tensorizer: FrameTensorizer,
         device: torch.device,
     ) -> None:
         """Initialize the adapter with a model, tensorizer, and target device."""
-        if not isinstance(model, torch.nn.Module):
-            raise TypeError("model must be a torch.nn.Module instance")
+        has_predict = callable(getattr(model, "predict", None))
+        # model does not have to be nn.Module
+        if not callable(model) and not has_predict:
+            raise TypeError("model must be callable or expose predict(tensor)")
         if not isinstance(tensorizer, FrameTensorizer):
             raise TypeError("tensorizer must be a FrameTensorizer instance")
         if not isinstance(device, torch.device):
@@ -71,7 +73,10 @@ class WindowModelAdapter:
 
         tensor = self._tensorizer.tensorize(list(window)).to(self._device)
         with torch.no_grad():
-            output = self._model(tensor)
+            if callable(self._model):
+                output = self._model(tensor)
+            else:
+                output = self._model.predict(tensor)
 
         if not isinstance(output, torch.Tensor):
             raise TypeError("model output must be a torch.Tensor")
@@ -169,7 +174,8 @@ def load_runtime_settings(config_path: Path) -> InferenceRuntimeSettings:
     class_labels = _parse_class_labels(inference_cfg.get("class_labels"))
     default_track_id = _parse_optional_track_id(
         tracking_cfg.get("default_track_id"))
-    device = _parse_optional_device(inference_cfg.get("device"), "inference.device")
+    device = _parse_optional_device(
+        inference_cfg.get("device"), "inference.device")
 
     return InferenceRuntimeSettings(
         target_resolution=target_resolution,
@@ -267,7 +273,8 @@ def _expand_batched_inference_results(
         prediction = result.prediction
         if isinstance(prediction, torch.Tensor) and prediction.ndim == 2:
             if prediction.shape[0] < 1:
-                raise ValueError("model output batch dimension must not be empty")
+                raise ValueError(
+                    "model output batch dimension must not be empty")
             for item_prediction in prediction:
                 expanded_results.append(
                     InferenceResult(

--- a/src/inference/mp4_cli.py
+++ b/src/inference/mp4_cli.py
@@ -211,7 +211,7 @@ def load_model_from_checkpoint(
 
     raw_state_dict = raw_checkpoint.get("model_state_dict", raw_checkpoint)
     state_dict = _validate_state_dict(raw_state_dict)
-    num_classes = _parse_num_classes(raw_checkpoint.get("num_classes"))
+    num_classes = _infer_num_classes(state_dict)
 
     model_name = raw_checkpoint.get("model_name")
     if model_name is not None and not isinstance(model_name, str):
@@ -439,13 +439,24 @@ def _validate_state_dict(value: object) -> dict[str, torch.Tensor]:
     return normalized
 
 
-def _parse_num_classes(value: object) -> int:
-    """Parse model class count from checkpoint metadata."""
-    if not isinstance(value, int) or isinstance(value, bool):
-        raise TypeError("num_classes in checkpoint must be an integer")
-    if value <= 0:
-        raise ValueError("num_classes in checkpoint must be > 0")
-    return value
+# checpoint file does not contain class count
+def _infer_num_classes(state_dict: dict[str, torch.Tensor]) -> int:
+    """Infer output class count from fc.weight shape."""
+    key_candidates = ("model.fc.weight", "fc.weight")
+    for key in key_candidates:
+        maybe_weight = state_dict.get(key)
+        if maybe_weight is None:
+            continue
+        if not isinstance(maybe_weight, torch.Tensor):
+            raise TypeError(f"{key} must be a torch.Tensor")
+        if maybe_weight.ndim != 2:
+            raise ValueError(f"{key} must be a rank-2 tensor")
+        return int(maybe_weight.shape[0])
+
+    raise ValueError(
+        "Could not infer number of classes from checkpoint. "
+        "Expected key 'model.fc.weight' or 'fc.weight'.",
+    )
 
 
 def _resolve_model_candidates(model_name: str | None) -> list[str]:

--- a/src/inference/mp4_cli.py
+++ b/src/inference/mp4_cli.py
@@ -1,7 +1,7 @@
 """MP4-to-JSON action inference CLI helpers."""
 
-from dataclasses import dataclass
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -46,7 +46,7 @@ class WindowModelAdapter:
 
     def __init__(
         self,
-        model: Any,
+        model: torch.nn.Module,
         tensorizer: FrameTensorizer,
         device: torch.device,
     ) -> None:
@@ -84,7 +84,8 @@ class WindowModelAdapter:
         if output.ndim == 1:
             return output.detach().cpu()
 
-        if output.ndim == 2:  # warging: in the future, there will be bug caused by ignoring other batch
+        # warning: in the future, there will be bug caused by ignoring other batch
+        if output.ndim == 2:
             if output.shape[0] < 1:
                 raise ValueError(
                     "model output batch dimension must not be empty")

--- a/src/inference/mp4_cli.py
+++ b/src/inference/mp4_cli.py
@@ -41,7 +41,7 @@ class WindowModelAdapter:
 
     def __init__(
         self,
-        model: torch.nn.Module,
+        model: torch.nn.Module,  # is model based on torch.nn.Module?
         tensorizer: FrameTensorizer,
         device: torch.device,
     ) -> None:
@@ -74,7 +74,7 @@ class WindowModelAdapter:
         if output.ndim == 1:
             return output.detach().cpu()
 
-        if output.ndim == 2:
+        if output.ndim == 2:  # warging: in the future, there will be bug caused by ignoring other batch
             if output.shape[0] < 1:
                 raise ValueError(
                     "model output batch dimension must not be empty")
@@ -92,7 +92,8 @@ def run_mp4_to_json_action_inference(request: InferenceCliRequest) -> int:
         raise ValueError("input_path must point to an .mp4 file")
 
     settings = load_runtime_settings(request.config_path)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = torch.device("cuda" if torch.cuda.is_available()
+                          else "cpu")  # it ignores mac
     model = load_model_from_checkpoint(request.checkpoint_path, device)
 
     tensorizer = FrameTensorizer(target_resolution=settings.target_resolution)
@@ -114,6 +115,7 @@ def run_mp4_to_json_action_inference(request: InferenceCliRequest) -> int:
 
     request.output_path.parent.mkdir(parents=True, exist_ok=True)
     writer.save(str(request.output_path))
+    # change to log
     print(
         f"[OK] Wrote {len(writer.get_log().events)} action events to: {request.output_path}")
 
@@ -183,7 +185,9 @@ def load_model_from_checkpoint(
         raise ValueError(
             f"Checkpoint path must point to a file: {checkpoint_path}")
 
-    raw_checkpoint = torch.load(str(checkpoint_path), map_location=device)
+    raw_checkpoint = torch.load(
+        # against Arbitrary Code Execution
+        str(checkpoint_path), map_location=device, weights_only=True)
     if not isinstance(raw_checkpoint, dict):
         raise TypeError("Checkpoint must contain a mapping/object payload")
 
@@ -332,6 +336,7 @@ def _validate_state_dict(value: object) -> dict[str, torch.Tensor]:
     return normalized
 
 
+# count of class should not be related to model, rather store it in metadata
 def _infer_num_classes(state_dict: dict[str, torch.Tensor]) -> int:
     """Infer output class count from fc.weight shape."""
     key_candidates = ("model.fc.weight", "fc.weight")

--- a/src/inference/mp4_cli.py
+++ b/src/inference/mp4_cli.py
@@ -78,7 +78,7 @@ class WindowModelAdapter:
             if output.shape[0] < 1:
                 raise ValueError(
                     "model output batch dimension must not be empty")
-            return output[0].detach().cpu()
+            return output.detach().cpu()
 
         raise ValueError("model output tensor must be 1D or 2D")
 
@@ -108,6 +108,7 @@ def run_mp4_to_json_action_inference(request: InferenceCliRequest) -> int:
     )
 
     _, _, inference_results = run_video(str(request.input_path), engine=engine)
+    inference_results = _expand_batched_inference_results(inference_results)
     track_ids = build_track_ids(inference_results, settings.default_track_id)
 
     writer = ActionEventWriter(class_labels=settings.class_labels)
@@ -244,6 +245,32 @@ def build_track_ids(
     if default_track_id is None:
         return [None] * len(results)
     return [default_track_id] * len(results)
+
+
+def _expand_batched_inference_results(
+    results: list[InferenceResult],
+) -> list[InferenceResult]:
+    """Expand 2D tensor predictions (batch, classes) into per-item results."""
+    expanded_results: list[InferenceResult] = []
+    for result in results:
+        prediction = result.prediction
+        if isinstance(prediction, torch.Tensor) and prediction.ndim == 2:
+            if prediction.shape[0] < 1:
+                raise ValueError("model output batch dimension must not be empty")
+            for item_prediction in prediction:
+                expanded_results.append(
+                    InferenceResult(
+                        window=result.window,
+                        start_frame_index=result.start_frame_index,
+                        end_frame_index=result.end_frame_index,
+                        start_timestamp=result.start_timestamp,
+                        end_timestamp=result.end_timestamp,
+                        prediction=item_prediction,
+                    )
+                )
+            continue
+        expanded_results.append(result)
+    return expanded_results
 
 
 def _ensure_mapping(value: object, field_name: str) -> dict[str, Any]:

--- a/src/inference/mp4_cli.py
+++ b/src/inference/mp4_cli.py
@@ -194,7 +194,7 @@ def load_model_from_checkpoint(
 
     raw_state_dict = raw_checkpoint.get("model_state_dict", raw_checkpoint)
     state_dict = _validate_state_dict(raw_state_dict)
-    num_classes = _infer_num_classes(state_dict)
+    num_classes = _parse_num_classes(raw_checkpoint.get("num_classes"))
 
     model_name = raw_checkpoint.get("model_name")
     if model_name is not None and not isinstance(model_name, str):
@@ -363,24 +363,13 @@ def _validate_state_dict(value: object) -> dict[str, torch.Tensor]:
     return normalized
 
 
-# count of class should not be related to model, rather store it in metadata
-def _infer_num_classes(state_dict: dict[str, torch.Tensor]) -> int:
-    """Infer output class count from fc.weight shape."""
-    key_candidates = ("model.fc.weight", "fc.weight")
-    for key in key_candidates:
-        maybe_weight = state_dict.get(key)
-        if maybe_weight is None:
-            continue
-        if not isinstance(maybe_weight, torch.Tensor):
-            raise TypeError(f"{key} must be a torch.Tensor")
-        if maybe_weight.ndim != 2:
-            raise ValueError(f"{key} must be a rank-2 tensor")
-        return int(maybe_weight.shape[0])
-
-    raise ValueError(
-        "Could not infer number of classes from checkpoint. "
-        "Expected key 'model.fc.weight' or 'fc.weight'.",
-    )
+def _parse_num_classes(value: object) -> int:
+    """Parse model class count from checkpoint metadata."""
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError("num_classes in checkpoint must be an integer")
+    if value <= 0:
+        raise ValueError("num_classes in checkpoint must be > 0")
+    return value
 
 
 def _resolve_model_candidates(model_name: str | None) -> list[str]:

--- a/src/inference/offline_runtime.py
+++ b/src/inference/offline_runtime.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 from queue import Queue
 from threading import Thread
+from typing import Any
 
 import cv2
 
@@ -45,12 +46,14 @@ def produce_frames(video_path: str, frame_queue: Queue) -> None:
     finally:
         frame_queue.put(EOF_SENTINEL)
 
+
 def produce_frames_safe(video_path: str, frame_queue: Queue, stats: dict) -> None:
     """Runs the frame producer and stores any raised exception in stats."""
     try:
         produce_frames(video_path, frame_queue)
     except Exception as exc:
         stats["producer_error"] = exc
+
 
 def consume_frame_queue(frame_queue: Queue, engine: InferenceEngine, stats: dict) -> None:
     """Consumes frames from a queue with an inference engine and updates runtime stats.
@@ -79,17 +82,28 @@ def consume_frame_queue(frame_queue: Queue, engine: InferenceEngine, stats: dict
     stats["inference_count"] = len(inference_results)
     stats["inference_results"] = inference_results
 
-def run_video(video_path: str) -> tuple[int, int, list]:
+
+def run_video(
+    video_path: str,
+    engine: InferenceEngine | None = None,
+) -> tuple[int, int, list[Any]]:
     """Runs offline inference on a single video file.
 
     Args:
         video_path (str): Path to the input video file.
+        engine (InferenceEngine | None): Optional inference engine instance. If None,
+            a default InferenceEngine is created.
 
     Returns:
         tuple[int, int, list]: Number of processed frames, generated inference results and collected
         inferencemetadata/results.
     """
-    engine = InferenceEngine()
+    runtime_engine = engine
+    if runtime_engine is None:
+        runtime_engine = InferenceEngine()
+    elif not isinstance(runtime_engine, InferenceEngine):
+        raise TypeError("engine must be an InferenceEngine instance or None")
+
     frame_queue = Queue()
     stats = {
         "frame_count": 0,
@@ -99,7 +113,7 @@ def run_video(video_path: str) -> tuple[int, int, list]:
     }
 
     producer = Thread(target=produce_frames_safe, args=(video_path, frame_queue, stats))
-    consumer = Thread(target=consume_frame_queue, args=(frame_queue, engine, stats))
+    consumer = Thread(target=consume_frame_queue, args=(frame_queue, runtime_engine, stats))
 
     producer.start()
     consumer.start()

--- a/src/inference/offline_runtime.py
+++ b/src/inference/offline_runtime.py
@@ -98,7 +98,7 @@ def run_video(
         tuple[int, int, list]: Number of processed frames, generated inference results and collected
         inferencemetadata/results.
     """
-    runtime_engine = engine
+    runtime_engine = engine  # engine initialization moved to mp4_cli.py
     if runtime_engine is None:
         runtime_engine = InferenceEngine()
     elif not isinstance(runtime_engine, InferenceEngine):
@@ -112,8 +112,10 @@ def run_video(
         "producer_error": None,
     }
 
-    producer = Thread(target=produce_frames_safe, args=(video_path, frame_queue, stats))
-    consumer = Thread(target=consume_frame_queue, args=(frame_queue, runtime_engine, stats))
+    producer = Thread(target=produce_frames_safe,
+                      args=(video_path, frame_queue, stats))
+    consumer = Thread(target=consume_frame_queue, args=(
+        frame_queue, runtime_engine, stats))
 
     producer.start()
     consumer.start()

--- a/src/main.py
+++ b/src/main.py
@@ -1,14 +1,27 @@
+"""Application entrypoints for startup summary and MP4-to-JSON inference CLI."""
+
+import argparse
 import json
 import sys
-from pathlib import Path
 from os import getenv
+from pathlib import Path
+from typing import Sequence
+
+import yaml
+
+from src.inference.mp4_cli import (
+    InferenceCliRequest,
+    run_mp4_to_json_action_inference,
+)
 
 DATA_DIR = Path(getenv("DATA_DIR", "/app/data/raw"))
 LOG_DIR = Path(getenv("LOG_DIR", "/app/data/logs"))
 
 VIDEO_EXTS = {".mp4", ".avi", ".mov", ".mkv", ".webm"}
 
-def main() -> int:
+
+def run_startup_summary() -> int:
+    """Scan dataset folder and write startup summary JSON."""
     LOG_DIR.mkdir(parents=True, exist_ok=True)
 
     if not DATA_DIR.exists():
@@ -33,5 +46,87 @@ def main() -> int:
 
     return 0
 
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build CLI parser for startup summary and Sprint 2 inference flow."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run startup summary (default) or MP4-to-JSON action inference "
+            "when --input and --checkpoint are provided."
+        ),
+    )
+    parser.add_argument(
+        "--input",
+        dest="input_path",
+        type=str,
+        default=None,
+        help="Path to input .mp4 file for inference mode",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        dest="checkpoint_path",
+        type=str,
+        default=None,
+        help="Path to model checkpoint (.pth) for inference mode",
+    )
+    parser.add_argument(
+        "--config",
+        dest="config_path",
+        type=str,
+        default="configs/data_pipeline.yml",
+        help="Path to YAML config with runtime settings",
+    )
+    parser.add_argument(
+        "--output",
+        dest="output_path",
+        type=str,
+        default="data/logs/actions.json",
+        help="Path where action inference JSON should be written",
+    )
+    return parser
+
+
+def _run_inference_mode(args: argparse.Namespace) -> int:
+    """Execute MP4-to-JSON inference mode from parsed CLI args."""
+    request = InferenceCliRequest(
+        input_path=Path(args.input_path),
+        checkpoint_path=Path(args.checkpoint_path),
+        config_path=Path(args.config_path),
+        output_path=Path(args.output_path),
+    )
+
+    try:
+        return run_mp4_to_json_action_inference(request)
+    except (
+        FileNotFoundError,
+        OSError,
+        RuntimeError,
+        TypeError,
+        ValueError,
+        KeyError,
+        yaml.YAMLError,
+    ) as error:
+        print(f"[ERROR] {error}")
+        return 1
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run app in startup-summary mode or MP4 inference mode."""
+    parser = build_parser()
+    parsed_args = parser.parse_args(list(argv) if argv is not None else [])
+
+    has_input = parsed_args.input_path is not None
+    has_checkpoint = parsed_args.checkpoint_path is not None
+
+    if not has_input and not has_checkpoint:
+        return run_startup_summary()
+
+    if has_input != has_checkpoint:
+        print("[ERROR] --input and --checkpoint must be provided together")
+        return 2
+
+    return _run_inference_mode(parsed_args)
+
+
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main(sys.argv[1:]))

--- a/src/main.py
+++ b/src/main.py
@@ -83,6 +83,14 @@ def build_parser() -> argparse.ArgumentParser:
         default="data/logs/actions.json",
         help="Path where action inference JSON should be written",
     )
+    parser.add_argument(
+        "--device",
+        dest="device",
+        type=str,
+        default=None,
+        choices=["auto", "cpu", "cuda", "mps"],
+        help="Optional device override for inference (auto, cpu, cuda, mps)",
+    )
     return parser
 
 
@@ -93,6 +101,7 @@ def _run_inference_mode(args: argparse.Namespace) -> int:
         checkpoint_path=Path(args.checkpoint_path),
         config_path=Path(args.config_path),
         output_path=Path(args.output_path),
+        device=args.device,
     )
 
     try:

--- a/tests/app/test_main.py
+++ b/tests/app/test_main.py
@@ -14,7 +14,7 @@ def test_main_writes_summary(tmp_path, monkeypatch):
     monkeypatch.setattr(app_main, "DATA_DIR", subset_dir)
     monkeypatch.setattr(app_main, "LOG_DIR", log_dir)
 
-    result = app_main.main()
+    result = app_main.main([])
 
     assert result == 0
 
@@ -24,3 +24,71 @@ def test_main_writes_summary(tmp_path, monkeypatch):
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
     assert summary["video_count"] == 1
     assert summary["class_count"] == 1
+
+
+def test_main_requires_input_and_checkpoint_together(tmp_path):
+    video_path = tmp_path / "sample.mp4"
+    video_path.write_bytes(b"")
+
+    result = app_main.main(["--input", str(video_path)])
+    assert result == 2
+
+
+def test_main_dispatches_inference_mode(monkeypatch, tmp_path):
+    input_path = tmp_path / "sample.mp4"
+    checkpoint_path = tmp_path / "model.pth"
+    config_path = tmp_path / "config.yml"
+    output_path = tmp_path / "actions.json"
+
+    input_path.write_bytes(b"")
+    checkpoint_path.write_bytes(b"")
+    config_path.write_text("pipeline: {}", encoding="utf-8")
+
+    captured = {}
+
+    def _fake_runner(request):
+        captured["request"] = request
+        return 0
+
+    monkeypatch.setattr(app_main, "run_mp4_to_json_action_inference", _fake_runner)
+
+    result = app_main.main(
+        [
+            "--input",
+            str(input_path),
+            "--checkpoint",
+            str(checkpoint_path),
+            "--config",
+            str(config_path),
+            "--output",
+            str(output_path),
+        ]
+    )
+    assert result == 0
+    assert captured["request"].input_path == input_path
+    assert captured["request"].checkpoint_path == checkpoint_path
+    assert captured["request"].config_path == config_path
+    assert captured["request"].output_path == output_path
+
+
+def test_main_inference_returns_non_zero_on_failure(monkeypatch, tmp_path):
+    input_path = tmp_path / "sample.mp4"
+    checkpoint_path = tmp_path / "model.pth"
+
+    input_path.write_bytes(b"")
+    checkpoint_path.write_bytes(b"")
+
+    def _failing_runner(_request):
+        raise ValueError("bad inference config")
+
+    monkeypatch.setattr(app_main, "run_mp4_to_json_action_inference", _failing_runner)
+
+    result = app_main.main(
+        [
+            "--input",
+            str(input_path),
+            "--checkpoint",
+            str(checkpoint_path),
+        ]
+    )
+    assert result == 1

--- a/tests/app/test_main.py
+++ b/tests/app/test_main.py
@@ -62,6 +62,8 @@ def test_main_dispatches_inference_mode(monkeypatch, tmp_path):
             str(config_path),
             "--output",
             str(output_path),
+            "--device",
+            "cpu",
         ]
     )
     assert result == 0
@@ -69,6 +71,7 @@ def test_main_dispatches_inference_mode(monkeypatch, tmp_path):
     assert captured["request"].checkpoint_path == checkpoint_path
     assert captured["request"].config_path == config_path
     assert captured["request"].output_path == output_path
+    assert captured["request"].device == "cpu"
 
 
 def test_main_inference_returns_non_zero_on_failure(monkeypatch, tmp_path):

--- a/tests/inference/test_mp4_cli.py
+++ b/tests/inference/test_mp4_cli.py
@@ -2,6 +2,7 @@
 
 import json
 
+import numpy as np
 import pytest
 import torch
 import yaml
@@ -9,11 +10,14 @@ import yaml
 from src.inference.engine import InferenceResult
 from src.inference.mp4_cli import (
     InferenceCliRequest,
+    WindowModelAdapter,
+    _expand_batched_inference_results,
     build_track_ids,
     load_model_from_checkpoint,
     load_runtime_settings,
     run_mp4_to_json_action_inference,
 )
+from src.inference.tensorize import FrameTensorizer
 from src.models.dummy import DummyBehaviorModel
 
 
@@ -99,3 +103,40 @@ def test_build_track_ids_supports_none_track_id():
     )
     track_ids = build_track_ids([result], default_track_id=None)
     assert track_ids == [None]
+
+
+def test_window_model_adapter_returns_full_batch_for_2d_output():
+    class _BatchModel(torch.nn.Module):
+        def forward(self, _: torch.Tensor) -> torch.Tensor:
+            return torch.tensor([[0.1, 0.9], [0.8, 0.2]], dtype=torch.float32)
+
+    adapter = WindowModelAdapter(
+        model=_BatchModel(),
+        tensorizer=FrameTensorizer(target_resolution=(8, 8)),
+        device=torch.device("cpu"),
+    )
+    frame = np.zeros((8, 8, 3), dtype=np.uint8)
+    prediction = adapter((frame,))
+
+    assert prediction.shape == (2, 2)
+    assert torch.allclose(
+        prediction,
+        torch.tensor([[0.1, 0.9], [0.8, 0.2]], dtype=torch.float32),
+    )
+
+
+def test_expand_batched_inference_results_splits_batch_prediction():
+    result = InferenceResult(
+        window=tuple(),
+        start_frame_index=0,
+        end_frame_index=3,
+        start_timestamp=0.0,
+        end_timestamp=0.1,
+        prediction=torch.tensor([[0.1, 0.9], [0.8, 0.2]], dtype=torch.float32),
+    )
+
+    expanded = _expand_batched_inference_results([result])
+
+    assert len(expanded) == 2
+    assert torch.allclose(expanded[0].prediction, torch.tensor([0.1, 0.9]))
+    assert torch.allclose(expanded[1].prediction, torch.tensor([0.8, 0.2]))

--- a/tests/inference/test_mp4_cli.py
+++ b/tests/inference/test_mp4_cli.py
@@ -1,0 +1,101 @@
+"""Tests for MP4 CLI inference helpers."""
+
+import json
+
+import pytest
+import torch
+import yaml
+
+from src.inference.engine import InferenceResult
+from src.inference.mp4_cli import (
+    InferenceCliRequest,
+    build_track_ids,
+    load_model_from_checkpoint,
+    load_runtime_settings,
+    run_mp4_to_json_action_inference,
+)
+from src.models.dummy import DummyBehaviorModel
+
+
+def _write_dummy_checkpoint(checkpoint_path):
+    torch.manual_seed(1234)
+    model = DummyBehaviorModel(num_classes=2)
+    checkpoint = {
+        "model_name": "dummy",
+        "model_state_dict": model.state_dict(),
+    }
+    torch.save(checkpoint, str(checkpoint_path))
+
+
+def test_run_mp4_to_json_action_inference_writes_output(dummy_video, tmp_path):
+    checkpoint_path = tmp_path / "dummy_checkpoint.pth"
+    config_path = tmp_path / "inference.yml"
+    output_path = tmp_path / "actions.json"
+
+    _write_dummy_checkpoint(checkpoint_path)
+
+    config = {
+        "pipeline": {
+            "target_resolution": [64, 64],
+            "temporal_window": 4,
+        },
+        "inference": {
+            "stride": 2,
+            "class_labels": ["idle", "moving"],
+        },
+        "tracking": {
+            "default_track_id": 1,
+        },
+    }
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    request = InferenceCliRequest(
+        input_path=dummy_video,
+        checkpoint_path=checkpoint_path,
+        config_path=config_path,
+        output_path=output_path,
+    )
+    exit_code = run_mp4_to_json_action_inference(request)
+
+    assert exit_code == 0
+    assert output_path.exists()
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["event_count"] > 0
+    assert len(payload["events"]) == payload["event_count"]
+    assert "confidence" in payload["events"][0]
+    assert payload["events"][0]["track_id"] == 1
+
+
+def test_load_runtime_settings_rejects_invalid_target_resolution(tmp_path):
+    config_path = tmp_path / "invalid.yml"
+    config_path.write_text("pipeline:\n  target_resolution: invalid\n", encoding="utf-8")
+
+    with pytest.raises(TypeError, match="pipeline.target_resolution"):
+        load_runtime_settings(config_path)
+
+
+def test_load_model_from_checkpoint_rejects_invalid_payload(tmp_path):
+    checkpoint_path = tmp_path / "bad_checkpoint.pth"
+    torch.save(["not", "a", "dict"], str(checkpoint_path))
+
+    with pytest.raises(TypeError, match="Checkpoint must contain"):
+        load_model_from_checkpoint(checkpoint_path, torch.device("cpu"))
+
+
+def test_build_track_ids_rejects_invalid_results_type():
+    with pytest.raises(TypeError, match="InferenceResult"):
+        build_track_ids([object()], default_track_id=1)
+
+
+def test_build_track_ids_supports_none_track_id():
+    result = InferenceResult(
+        window=tuple(),
+        start_frame_index=0,
+        end_frame_index=3,
+        start_timestamp=0.0,
+        end_timestamp=0.1,
+        prediction=torch.tensor([0.1, 0.9]),
+    )
+    track_ids = build_track_ids([result], default_track_id=None)
+    assert track_ids == [None]

--- a/tests/inference/test_mp4_cli.py
+++ b/tests/inference/test_mp4_cli.py
@@ -15,6 +15,7 @@ from src.inference.mp4_cli import (
     build_track_ids,
     load_model_from_checkpoint,
     load_runtime_settings,
+    resolve_inference_device,
     run_mp4_to_json_action_inference,
 )
 from src.inference.tensorize import FrameTensorizer
@@ -78,6 +79,24 @@ def test_load_runtime_settings_rejects_invalid_target_resolution(tmp_path):
 
     with pytest.raises(TypeError, match="pipeline.target_resolution"):
         load_runtime_settings(config_path)
+
+
+def test_load_runtime_settings_reads_device_override(tmp_path):
+    config_path = tmp_path / "inference.yml"
+    config_path.write_text(
+        (
+            "pipeline:\n"
+            "  target_resolution: [64, 64]\n"
+            "  temporal_window: 4\n"
+            "inference:\n"
+            "  stride: 1\n"
+            "  device: mps\n"
+        ),
+        encoding="utf-8",
+    )
+
+    settings = load_runtime_settings(config_path)
+    assert settings.device == "mps"
 
 
 def test_load_model_from_checkpoint_rejects_invalid_payload(tmp_path):
@@ -156,3 +175,29 @@ def test_expand_batched_inference_results_splits_batch_prediction():
     assert len(expanded) == 2
     assert torch.allclose(expanded[0].prediction, torch.tensor([0.1, 0.9]))
     assert torch.allclose(expanded[1].prediction, torch.tensor([0.8, 0.2]))
+
+
+def test_resolve_inference_device_prefers_cli_over_config(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    class _MPSBackend:
+        @staticmethod
+        def is_available():
+            return True
+
+    monkeypatch.setattr(torch.backends, "mps", _MPSBackend())
+    device = resolve_inference_device(cli_device="cpu", config_device="mps")
+    assert device.type == "cpu"
+
+
+def test_resolve_inference_device_auto_uses_mps_when_cuda_unavailable(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    class _MPSBackend:
+        @staticmethod
+        def is_available():
+            return True
+
+    monkeypatch.setattr(torch.backends, "mps", _MPSBackend())
+    device = resolve_inference_device(cli_device=None, config_device=None)
+    assert device.type == "mps"

--- a/tests/inference/test_mp4_cli.py
+++ b/tests/inference/test_mp4_cli.py
@@ -26,6 +26,7 @@ def _write_dummy_checkpoint(checkpoint_path):
     model = DummyBehaviorModel(num_classes=2)
     checkpoint = {
         "model_name": "dummy",
+        "num_classes": 2,
         "model_state_dict": model.state_dict(),
     }
     torch.save(checkpoint, str(checkpoint_path))
@@ -84,6 +85,21 @@ def test_load_model_from_checkpoint_rejects_invalid_payload(tmp_path):
     torch.save(["not", "a", "dict"], str(checkpoint_path))
 
     with pytest.raises(TypeError, match="Checkpoint must contain"):
+        load_model_from_checkpoint(checkpoint_path, torch.device("cpu"))
+
+
+def test_load_model_from_checkpoint_requires_num_classes_metadata(tmp_path):
+    checkpoint_path = tmp_path / "missing_num_classes.pth"
+    model = DummyBehaviorModel(num_classes=2)
+    torch.save(
+        {
+            "model_name": "dummy",
+            "model_state_dict": model.state_dict(),
+        },
+        str(checkpoint_path),
+    )
+
+    with pytest.raises(TypeError, match="num_classes in checkpoint"):
         load_model_from_checkpoint(checkpoint_path, torch.device("cpu"))
 
 

--- a/tests/inference/test_mp4_cli.py
+++ b/tests/inference/test_mp4_cli.py
@@ -27,7 +27,6 @@ def _write_dummy_checkpoint(checkpoint_path):
     model = DummyBehaviorModel(num_classes=2)
     checkpoint = {
         "model_name": "dummy",
-        "num_classes": 2,
         "model_state_dict": model.state_dict(),
     }
     torch.save(checkpoint, str(checkpoint_path))
@@ -107,8 +106,8 @@ def test_load_model_from_checkpoint_rejects_invalid_payload(tmp_path):
         load_model_from_checkpoint(checkpoint_path, torch.device("cpu"))
 
 
-def test_load_model_from_checkpoint_requires_num_classes_metadata(tmp_path):
-    checkpoint_path = tmp_path / "missing_num_classes.pth"
+def test_load_model_from_checkpoint_infers_num_classes_from_state_dict(tmp_path):
+    checkpoint_path = tmp_path / "checkpoint.pth"
     model = DummyBehaviorModel(num_classes=2)
     torch.save(
         {
@@ -118,8 +117,8 @@ def test_load_model_from_checkpoint_requires_num_classes_metadata(tmp_path):
         str(checkpoint_path),
     )
 
-    with pytest.raises(TypeError, match="num_classes in checkpoint"):
-        load_model_from_checkpoint(checkpoint_path, torch.device("cpu"))
+    loaded_model = load_model_from_checkpoint(checkpoint_path, torch.device("cpu"))
+    assert isinstance(loaded_model, DummyBehaviorModel)
 
 
 def test_build_track_ids_rejects_invalid_results_type():

--- a/tests/inference/test_mp4_cli.py
+++ b/tests/inference/test_mp4_cli.py
@@ -160,6 +160,42 @@ def test_window_model_adapter_returns_full_batch_for_2d_output():
     )
 
 
+def test_window_model_adapter_accepts_callable_non_module_model():
+    class _CallableModel:
+        def __call__(self, _: torch.Tensor) -> torch.Tensor:
+            return torch.tensor([0.3, 0.7], dtype=torch.float32)
+
+    adapter = WindowModelAdapter(
+        model=_CallableModel(),
+        tensorizer=FrameTensorizer(target_resolution=(8, 8)),
+        device=torch.device("cpu"),
+    )
+    frame = np.zeros((8, 8, 3), dtype=np.uint8)
+    prediction = adapter((frame,))
+    assert torch.allclose(
+        prediction,
+        torch.tensor([0.3, 0.7], dtype=torch.float32),
+    )
+
+
+def test_window_model_adapter_accepts_predict_only_model():
+    class _PredictModel:
+        def predict(self, _: torch.Tensor) -> torch.Tensor:
+            return torch.tensor([0.4, 0.6], dtype=torch.float32)
+
+    adapter = WindowModelAdapter(
+        model=_PredictModel(),
+        tensorizer=FrameTensorizer(target_resolution=(8, 8)),
+        device=torch.device("cpu"),
+    )
+    frame = np.zeros((8, 8, 3), dtype=np.uint8)
+    prediction = adapter((frame,))
+    assert torch.allclose(
+        prediction,
+        torch.tensor([0.4, 0.6], dtype=torch.float32),
+    )
+
+
 def test_expand_batched_inference_results_splits_batch_prediction():
     result = InferenceResult(
         window=tuple(),


### PR DESCRIPTION
What changed

 1. Batch-safe inference output handling
  - WindowModelAdapter no longer drops predictions by returning output[0] for 2D outputs.
  - Full batch outputs are now propagated.
  - Added _expand_batched_inference_results(...) so batched predictions are expanded into per-result items before writing events.
 2. Checkpoint loading no longer depends on fc.weight
  - Removed class count inference from specific layer names.
  - num_classes is now required in checkpoint metadata and parsed explicitly.
  - Updated training checkpoint save logic to include:
   - model_name
   - num_classes
   - model_state_dict
 3. Device resolution updated for 2024+ hardware
  - Added explicit device resolver with fallback order: cuda -> mps -> cpu.
  - Added overrides through:
   - CLI: --device {auto,cpu,cuda,mps}
   - config: inference.device
  - CLI override has priority over config.
 4. Library/helper logging behavior fixed
  - Replaced hard print(...) in mp4_cli.py with logger.info(...) to support proper pipeline logging control.
 5. Model adapter generalized
 6. Docs and tests updated
  - Updated inference/README docs for checkpoint metadata and device options.
  - Added/updated tests for:
   - batch output handling
   - metadata-required checkpoint loading
   - device override behavior
   - non-nn.Module model adapter compatibility

## Why
These changes remove fragile assumptions (single-batch output, fc-specific checkpoints, CUDA/CPU-only logic, strict module inheritance) and make the inference path robust for future model/backbone/runtime
changes, including Apple Silicon (mps) and debug workflows forcing CPU.

## Linked Issue

Closes #45

## Checklist
 - [X]  Changes were tested locally
 - [x]  CI passes
 - [X]  README/docs updated if relevant
 - [X]  Scope matches the linked Issue
 - [X]  No direct work outside the agreed scope