### PR TITLE
Add tracker abstraction and initial single-track backend

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -1,6 +1,6 @@
 # Inference
 ## Coauthor: [Aleksander Kaźmierczak](https://github.com/blanqtoja)
-## Coauthor: [Ireneusz Bartoszek](...)
+## Coauthor: [Ireneusz Bartoszek](https://github.com/bartoszir)
 
 [Back to README](../README.md)
 

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -1,5 +1,6 @@
 # Inference
-## Author: [Aleksander Kaźmierczak](https://github.com/blanqtoja)
+## Coauthor: [Aleksander Kaźmierczak](https://github.com/blanqtoja)
+## Coauthor: [Ireneusz Bartoszek](...)
 
 [Back to README](../README.md)
 
@@ -38,6 +39,19 @@ If neither is provided, `src.main` runs startup summary mode.
 5. Convert `InferenceResult` objects to `ActionEvent` records.
 6. Save action log JSON with `ActionEventWriter`.
 
+### Offline runtime details
+
+The offline runtime processes video frames using a producer-consumer pattern:
+
+- A producer thread reads frames from the input MP4 file in source order.
+- A consumer thread feeds frames into the `InferenceEngine`.
+- Frame buffering and windowing are handled internally by the engine.
+
+The runtime guarantees:
+- deterministic frame ordering
+- safe shutdown using an EOF sentinel
+- propagation of frame indices and timestamps in `InferenceResult`
+
 ## Supported config keys
 
 ```yaml
@@ -66,3 +80,31 @@ Device resolution order:
 Inference expects checkpoint metadata fields:
 - `model_name` (supported: `baseline`, `dummy`)
 - `model_state_dict`
+
+## Tracking
+
+Tracking is implemented through a simple abstraction layer:
+
+- `BaseTracker` defines the interface for assigning track IDs
+- `SingleTrackTracker` is the initial backend implementation
+
+### Current behavior
+
+- A single persistent `track_id` is assigned to all inference results
+- Track IDs are propagated into `ActionEvent` records
+- Tracking operates on inference windows, not raw frames
+
+### Integration in pipeline
+
+1. `InferenceEngine` produces `InferenceResult` objects
+2. Tracker assigns `track_id` values to each result
+3. `ActionEventWriter` includes `track_id` in output events
+
+### Limitations
+
+- Assumes a single continuous subject or identity
+- No multi-object tracking support
+- No spatial matching (no bounding boxes or IoU-based association)
+- No re-identification across disjoint segments
+
+This implementation serves as a baseline for future multi-object tracking extensions.

--- a/src/inference/mp4_cli.py
+++ b/src/inference/mp4_cli.py
@@ -120,7 +120,7 @@ def run_mp4_to_json_action_inference(request: InferenceCliRequest) -> int:
         model=model_adapter,
     )
 
-    _, _, inference_results = run_video(str(request.input_path), engine=engine)
+    _, _, inference_results,_ = run_video(str(request.input_path), engine=engine)
     inference_results = _expand_batched_inference_results(inference_results)
     track_ids = build_track_ids(inference_results, settings.default_track_id)
 

--- a/src/inference/offline_runtime.py
+++ b/src/inference/offline_runtime.py
@@ -2,11 +2,13 @@
 from pathlib import Path
 from queue import Queue
 from threading import Thread
-from typing import Any
+from typing import Any, Optional
 
 import cv2
 
 from src.inference.engine import InferenceEngine
+from src.inference.json_writer import ActionEventWriter
+from src.inference.tracker import BaseTracker, SingleTrackTracker
 
 EOF_SENTINEL = object()
 
@@ -85,18 +87,21 @@ def consume_frame_queue(frame_queue: Queue, engine: InferenceEngine, stats: dict
 
 def run_video(
     video_path: str,
-    engine: InferenceEngine | None = None,
-) -> tuple[int, int, list[Any]]:
+    engine: Optional[InferenceEngine] = None,
+    tracker: Optional[BaseTracker] = None
+) -> tuple[int, int, list[Any], list[Any]]:
     """Runs offline inference on a single video file.
 
     Args:
         video_path (str): Path to the input video file.
-        engine (InferenceEngine | None): Optional inference engine instance. If None,
-            a default InferenceEngine is created.
+        engine: Optional inference engine instance. If None, a default
+            InferenceEngine is created.
+        tracker: Optional tracker used to assign track IDs to inference results.
 
     Returns:
-        tuple[int, int, list]: Number of processed frames, generated inference results and collected
-        inferencemetadata/results.
+        tuple[int, int, list[Any], list[Any]]: Number of processed frames,
+        number of inference windows, collected inference results, and output
+        action events.
     """
     runtime_engine = engine  # engine initialization moved to mp4_cli.py
     if runtime_engine is None:
@@ -114,8 +119,8 @@ def run_video(
 
     producer = Thread(target=produce_frames_safe,
                       args=(video_path, frame_queue, stats))
-    consumer = Thread(target=consume_frame_queue, args=(
-        frame_queue, runtime_engine, stats))
+    consumer = Thread(target=consume_frame_queue,
+                      args=(frame_queue, runtime_engine, stats))
 
     producer.start()
     consumer.start()
@@ -130,7 +135,15 @@ def run_video(
     inference_count = stats["inference_count"]
     inference_results = stats["inference_results"]
 
+    tracker = tracker or SingleTrackTracker()
+    track_ids = tracker.assign_track_ids(inference_results)
+
+    writer = ActionEventWriter()
+    writer.add_results(inference_results, track_ids=track_ids)
+    action_events = writer.get_log().events
+
     print(f"Processed {frame_count} frames")
     print(f"Generated {inference_count} inference windows")
+    print(f"Generated {len(action_events)} action events")
 
-    return frame_count, inference_count, inference_results
+    return frame_count, inference_count, inference_results, action_events

--- a/src/inference/tracker.py
+++ b/src/inference/tracker.py
@@ -1,0 +1,33 @@
+"""Tracker abstractions and simple tracking backends for inference results."""
+
+from abc import ABC, abstractmethod
+from typing import List, Optional
+
+from src.inference.engine import InferenceResult
+
+
+class BaseTracker(ABC):
+    """Abstract tracker interface for assigning track IDs to inference results."""
+
+    @abstractmethod
+    def assign_track_ids(self, results: List[InferenceResult]) -> List[Optional[int]]:
+        """Assign track IDs to inference results.
+
+        Args:
+            results: Inference results to associate across frames/windows.
+
+        Returns:
+            List of track IDs aligned with the input results.
+        """
+        raise NotImplementedError
+
+class SingleTrackTracker(BaseTracker):
+    """Simple tracker that assigns a single persistent track ID to all results."""
+
+    def __init__(self, track_id: int = 1) -> None:
+        """Initialize the tracker with a fixed track ID."""
+        self.track_id = track_id
+
+    def assign_track_ids(self, results: List[InferenceResult]) -> List[Optional[int]]:
+        """Assign the same track ID to every result."""
+        return [self.track_id for _ in results]

--- a/src/inference/tracker.py
+++ b/src/inference/tracker.py
@@ -36,8 +36,11 @@ class SingleTrackTracker(BaseTracker):
 
     def __init__(self, track_id: int = 1) -> None:
         """Initialize the tracker with a fixed track ID."""
+        if not isinstance(track_id, int) or isinstance(track_id, bool):
+            raise TypeError("track_id must be an integer")
+
         self.track_id = track_id
 
     def assign_track_ids(self, results: List[InferenceResult]) -> List[Optional[int]]:
         """Assign the same track ID to every result."""
-        return [self.track_id for _ in results]
+        return [self.track_id] * len(results)

--- a/src/inference/tracker.py
+++ b/src/inference/tracker.py
@@ -22,7 +22,17 @@ class BaseTracker(ABC):
         raise NotImplementedError
 
 class SingleTrackTracker(BaseTracker):
-    """Simple tracker that assigns a single persistent track ID to all results."""
+    """Simple tracker that assigns a single persistent track ID to all results.
+
+    Assumptions:
+        - The current pipeline represents a single continuous subject/track.
+        - Results belong to one identity across consecutive inference windows.
+
+    Limitations:
+        - Does not perform multi-object association.
+        - Does not use spatial matching, bounding boxes, or re-identification.
+        - Intended as an initial stable backend until richer tracking inputs are available.
+    """
 
     def __init__(self, track_id: int = 1) -> None:
         """Initialize the tracker with a fixed track ID."""

--- a/tests/inference/test_offline_runtime.py
+++ b/tests/inference/test_offline_runtime.py
@@ -2,6 +2,7 @@ import cv2
 import numpy as np
 import pytest
 
+from src.inference.engine import InferenceEngine
 from src.inference.offline_runtime import run_video
 
 
@@ -31,9 +32,11 @@ def test_run_video_processes_sample_mp4_and_exposes_track_id(tmp_path):
 
     writer.release()
 
+    engine = InferenceEngine(model=DummyPredictionModel())
+
     processed_frames, inference_windows, inference_results, action_events = run_video(
         str(video_path),
-        model=DummyPredictionModel(),
+        engine=engine,
     )
 
     assert processed_frames == 20

--- a/tests/inference/test_offline_runtime.py
+++ b/tests/inference/test_offline_runtime.py
@@ -5,13 +5,16 @@ import pytest
 from src.inference.offline_runtime import run_video
 
 
+class DummyPredictionModel:
+    def __call__(self, window):
+        return {"label": "action", "confidence": 0.9}
+
 def test_run_video_raises_on_invalid_path_without_hanging():
     with pytest.raises(FileNotFoundError):
         run_video("path/that/does/not/exist.mp4")
 
-def test_run_video_processes_sample_mp4(tmp_path):
-
-    video_path = tmp_path / "video.mp4"
+def test_run_video_processes_sample_mp4_and_exposes_track_id(tmp_path):
+    video_path = tmp_path / "sample.mp4"
 
     writer = cv2.VideoWriter(
         str(video_path),
@@ -28,16 +31,21 @@ def test_run_video_processes_sample_mp4(tmp_path):
 
     writer.release()
 
-    processed_frames, inference_windows, inference_results = run_video(str(video_path))
+    processed_frames, inference_windows, inference_results, action_events = run_video(
+        str(video_path),
+        model=DummyPredictionModel(),
+    )
 
     assert processed_frames == 20
     assert inference_windows > 0
     assert len(inference_results) == inference_windows
+    assert len(action_events) == inference_windows
 
     first_result = inference_results[0]
     assert first_result.start_frame_index >= 1
     assert first_result.end_frame_index >= first_result.start_frame_index
-
     assert first_result.start_timestamp is not None
     assert first_result.end_timestamp is not None
     assert first_result.end_timestamp >= first_result.start_timestamp
+
+    assert all(event.track_id == 1 for event in action_events)

--- a/tests/inference/test_tracker.py
+++ b/tests/inference/test_tracker.py
@@ -1,0 +1,37 @@
+from src.inference.engine import InferenceResult
+from src.inference.tracker import SingleTrackTracker
+
+
+def test_single_track_tracker_assigns_consistent_track_id():
+    tracker = SingleTrackTracker(track_id=1)
+
+    results = [
+        InferenceResult(
+            window=("f1", "f2"),
+            start_frame_index=1,
+            end_frame_index=2,
+            start_timestamp=1.0,
+            end_timestamp=2.0,
+            prediction={"label": "action", "confidence": 0.9},
+        ),
+        InferenceResult(
+            window=("f2", "f3"),
+            start_frame_index=2,
+            end_frame_index=3,
+            start_timestamp=2.0,
+            end_timestamp=3.0,
+            prediction={"label": "action", "confidence": 0.9},
+        ),
+        InferenceResult(
+            window=("f3", "f4"),
+            start_frame_index=3,
+            end_frame_index=4,
+            start_timestamp=3.0,
+            end_timestamp=4.0,
+            prediction={"label": "action", "confidence": 0.9},
+        ),
+    ]
+
+    track_ids = tracker.assign_track_ids(results)
+
+    assert track_ids == [1, 1, 1]


### PR DESCRIPTION
## Summary
This PR introduces a tracker abstraction and integrates an initial simple tracking backend to preserve identity continuity across frames.

The implementation adds a tracker interface and connects it to the offline inference pipeline, enabling propagation of `track_id` into ActionEvent outputs.

## Linked Issue
Closes #47

## What was added
- tracker interface (`BaseTracker`)
- initial backend (`SingleTrackTracker`) assigning a persistent track_id
- integration of tracking into the offline runtime pipeline
- propagation of `track_id` into `ActionEvent` output records
- unit test for tracker backend
- integration test verifying track_id continuity in runtime

## Testing
- manually verified using offline runtime
- `python -m pytest tests/inference/test_tracker.py -q`
- `python -m pytest tests/inference/test_offline_runtime.py -q`
- `python -m pytest tests/inference -q`

## Notes / Limitations
- current backend assumes a single continuous subject/track
- no multi-object tracking or spatial association yet
- no bounding box or re-identification logic is used
- intended as an initial stable implementation for future extensions

## Checklist
- [x] Changes were tested locally
- [x] CI passes
- [x] README/docs updated if relevant
- [x] Scope matches the linked Issue
- [x] No direct work outside the agreed scope