### PR TITLE
Use python -m to run src.main

### DIFF
--- a/.github/workflows/nightly-full-dataset.yml
+++ b/.github/workflows/nightly-full-dataset.yml
@@ -67,7 +67,7 @@ jobs:
           docker compose run --rm \
             -e DATA_DIR=/app/data/nightly_raw \
             -e LOG_DIR=/app/data/nightly_logs \
-            inference sh -lc "python src/main.py"
+            inference sh -lc "python -m src.main"
 
       - name: Validate startup summary
         shell: bash


### PR DESCRIPTION
## Summary
Change the nightly workflow command to invoke the app as a module (`python -m src.main`) instead of running the script file. This improves package/module resolution and avoids relative import issues when running inside the docker-compose job.

## Linked Issue
Closes #68 

## Checklist
- [x] Changes were tested locally
- [x] CI passes
- [x] README/docs updated if relevant
- [x] Scope matches the linked Issue
- [x] No direct work outside the agreed scope