### PR TITLE
Add context extraction and attach to events

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -1,6 +1,7 @@
 # Inference
 ## Coauthor: [Aleksander Kaźmierczak](https://github.com/blanqtoja)
 ## Coauthor: [Ireneusz Bartoszek](https://github.com/bartoszir)
+## Coauthor: [Łukasz Murza](https://github.com/XEN00000)
 
 [Back to README](../README.md)
 
@@ -15,7 +16,6 @@ docker compose run --rm inference python -m src.main \
   --output /app/data/logs/actions.json \
   --device auto
 ```
-
 
 ### Arguments
 
@@ -108,3 +108,35 @@ Tracking is implemented through a simple abstraction layer:
 - No re-identification across disjoint segments
 
 This implementation serves as a baseline for future multi-object tracking extensions.
+
+## Sprint 3: Minimal Context Module
+
+### Overview
+To support context-aware alerting in Sprint 3, a lightweight **Context Module** has been integrated into the inference pipeline. This module identifies the environmental setting of a video clip without requiring retraining of the primary action-recognition baseline.
+
+### Technical Implementation
+- **Model:** Pre-trained MobileNetV2 (ImageNetV2 weights).
+- **Approach:** Zero-shot scene classification via index mapping. The module analyzes the first frame of each video to determine the global context.
+- **Performance:** Deterministic output confirmed via local verification tests (`tests/inference/test_context.py`).
+
+### Output Contract
+The `ContextModule` extends the `ActionEvent` schema. Every event produced in `actions.json` now includes a `context` object:
+
+```json
+"context": {
+  "scene_tag": "string",
+  "confidence": 0.85
+}
+```
+
+**Supported Tags:**
+- `outdoor`: Parks, streets, open areas.
+- `indoor`: Rooms, hallways, office spaces.
+- `vehicle_setting`: Car interiors or immediate transport surroundings.
+- `unknown`: Fallback for low-confidence or ambiguous scenes.
+
+### Integration Assumptions for Alerting
+The alerting logic (downstream in Sprint 3) is expected to consume the `scene_tag` to apply conditional filters:
+1. **Contextual Thresholds:** Alerts for "running" might have a higher priority in `indoor` settings compared to `outdoor`.
+2. **Deterministic Mapping:** The alerting system can rely on the `scene_tag` being consistent across the entire video duration as it is derived from the initial state.
+3. **Fallback Logic:** If `scene_tag` is `unknown`, the alerting system should default to the most restrictive safety policy.

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -138,5 +138,8 @@ The `ContextModule` extends the `ActionEvent` schema. Every event produced in `a
 ### Integration Assumptions for Alerting
 The alerting logic (downstream in Sprint 3) is expected to consume the `scene_tag` to apply conditional filters:
 1. **Contextual Thresholds:** Alerts for "running" might have a higher priority in `indoor` settings compared to `outdoor`.
-2. **Deterministic Mapping:** The alerting system can rely on the `scene_tag` being consistent across the entire video duration as it is derived from the initial state.
+2. **First-Frame Context Assumption (Global Context):** 
+   - **Crucial:** The `scene_tag` is extracted ONLY from the first valid frame of the video and applied uniformly to all events in the stream.
+   - It does NOT support dynamic scene changes (e.g., transitioning from indoor to outdoor within a single clip). 
+   - Downstream logic must treat this as a "Global Scene Label" for the entire inference session.
 3. **Fallback Logic:** If `scene_tag` is `unknown`, the alerting system should default to the most restrictive safety policy.

--- a/src/inference/action_event.py
+++ b/src/inference/action_event.py
@@ -29,6 +29,7 @@ class ActionEvent:
     start_timestamp: Optional[float] = None
     end_timestamp: Optional[float] = None
     track_id: Optional[int] = None
+    context: Optional[dict] = None
 
     def __post_init__(self) -> None:
         """Validate fields after initialization."""
@@ -71,6 +72,10 @@ class ActionEvent:
         if self.track_id is not None:
             if not isinstance(self.track_id, int) or isinstance(self.track_id, bool):
                 raise TypeError("track_id must be an integer")
+
+        if self.context is not None:
+            if not isinstance(self.context, dict):
+                raise TypeError("context must be a dictionary")
 
     def to_dict(self) -> dict:
         """Convert to dictionary, filtering out None values."""

--- a/src/inference/action_event.py
+++ b/src/inference/action_event.py
@@ -83,7 +83,8 @@ class ActionEvent:
             if not isinstance(self.context["scene_tag"], str):
                 raise TypeError("scene_tag must be a string")
             
-            if not isinstance(self.context["confidence"], (float, int)) or isinstance(self.context["confidence"], bool):
+            conf = self.context["confidence"]
+            if not isinstance(conf, (float, int)) or isinstance(conf, bool):
                 raise TypeError("confidence must be a float")
 
     def to_dict(self) -> dict:

--- a/src/inference/action_event.py
+++ b/src/inference/action_event.py
@@ -76,6 +76,15 @@ class ActionEvent:
         if self.context is not None:
             if not isinstance(self.context, dict):
                 raise TypeError("context must be a dictionary")
+            
+            if "scene_tag" not in self.context or "confidence" not in self.context:
+                raise ValueError("context missing required keys: 'scene_tag' or 'confidence'")
+                
+            if not isinstance(self.context["scene_tag"], str):
+                raise TypeError("scene_tag must be a string")
+            
+            if not isinstance(self.context["confidence"], (float, int)) or isinstance(self.context["confidence"], bool):
+                raise TypeError("confidence must be a float")
 
     def to_dict(self) -> dict:
         """Convert to dictionary, filtering out None values."""

--- a/src/inference/context_adapter.py
+++ b/src/inference/context_adapter.py
@@ -1,0 +1,50 @@
+"""Minimal context module for Sprint 3 context-aware alerting."""
+import torch
+import torchvision.models as models
+import torchvision.transforms as T
+import torch.nn.functional as F
+from PIL import Image
+
+class ContextModule:
+    """Extracts scene tags from video frames without retraining."""
+    
+    def __init__(self):
+        # Load pre-trained MobileNetV2
+        self.model = models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V2)
+        self.model.eval()
+
+        self.transform = T.Compose([
+            T.Resize(256),
+            T.CenterCrop(224),
+            T.ToTensor(),
+            T.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
+        ])
+
+        # Minimal context map per Sprint 3 requirements
+        self.context_map = {
+            "outdoor": range(400, 900),
+            "indoor": range(0, 400),
+            "vehicle_setting": range(900, 1000)
+        }
+
+    def get_context(self, frame_tensor):
+        """
+        Args:
+            frame_tensor: PIL Image or Tensor frame
+        Returns:
+            dict: Context output contract with scene_tag and confidence.
+        """
+        with torch.no_grad():
+            img = self.transform(frame_tensor).unsqueeze(0)
+            output = self.model(img)
+            
+            probabilities = F.softmax(output, dim=1)
+            confidence, predicted_idx = torch.max(probabilities, 1)
+            
+            idx = predicted_idx.item()
+            conf_val = round(confidence.item(), 3)
+
+            for context, indexes in self.context_map.items():
+                if idx in indexes:
+                    return {"scene_tag": context, "confidence": conf_val}
+            return {"scene_tag": "unknown", "confidence": conf_val}

--- a/src/inference/context_adapter.py
+++ b/src/inference/context_adapter.py
@@ -1,46 +1,49 @@
 """Minimal context module for Sprint 3 context-aware alerting."""
+
+from PIL.Image import Image
 import torch
+import torch.nn.functional as F
 import torchvision.models as models
 import torchvision.transforms as T
-import torch.nn.functional as F
-from PIL import Image
+
 
 class ContextModule:
     """Extracts scene tags from video frames without retraining."""
-    
-    def __init__(self):
-        # Load pre-trained MobileNetV2
-        self.model = models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V2)
+
+    def __init__(self) -> None:
+        """Initialize the ContextModule with pre-trained MobileNetV2."""
+        self.model = models.mobilenet_v2(weights=models.MobileNetV2_Weights.IMAGENET1K_V2)
         self.model.eval()
 
         self.transform = T.Compose([
             T.Resize(256),
             T.CenterCrop(224),
             T.ToTensor(),
-            T.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
+            T.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
         ])
 
-        # Minimal context map per Sprint 3 requirements
         self.context_map = {
             "outdoor": range(400, 900),
             "indoor": range(0, 400),
-            "vehicle_setting": range(900, 1000)
+            "vehicle_setting": range(900, 1000),
         }
 
-    def get_context(self, frame_tensor):
-        """
+    def get_context(self, frame_tensor: Image) -> dict:
+        """Extract context from a given frame.
+
         Args:
-            frame_tensor: PIL Image or Tensor frame
+            frame_tensor: PIL Image or Tensor frame.
+
         Returns:
             dict: Context output contract with scene_tag and confidence.
         """
         with torch.no_grad():
             img = self.transform(frame_tensor).unsqueeze(0)
             output = self.model(img)
-            
+
             probabilities = F.softmax(output, dim=1)
             confidence, predicted_idx = torch.max(probabilities, 1)
-            
+
             idx = predicted_idx.item()
             conf_val = round(confidence.item(), 3)
 

--- a/src/inference/context_adapter.py
+++ b/src/inference/context_adapter.py
@@ -12,7 +12,7 @@ class ContextModule:
 
     def __init__(self) -> None:
         """Initialize the ContextModule with pre-trained MobileNetV2."""
-        self.model = models.mobilenet_v2(weights=models.MobileNetV2_Weights.IMAGENET1K_V2)
+        self.model = models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V2)
         self.model.eval()
 
         self.transform = T.Compose([

--- a/src/inference/context_adapter.py
+++ b/src/inference/context_adapter.py
@@ -1,10 +1,10 @@
 """Minimal context module for Sprint 3 context-aware alerting."""
 
-from PIL.Image import Image
 import torch
 import torch.nn.functional as F
 import torchvision.models as models
 import torchvision.transforms as T
+from PIL.Image import Image
 
 
 class ContextModule:

--- a/src/inference/context_adapter.py
+++ b/src/inference/context_adapter.py
@@ -22,7 +22,7 @@ class ContextModule:
             T.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
         ])
 
-        # Semantycznie poprawne mapowanie klas pod monitoring (Addressing Łukasz's review)
+        
         self.context_map = {
             "outdoor": [
                 919, 920, # Street sign, traffic light

--- a/src/inference/context_adapter.py
+++ b/src/inference/context_adapter.py
@@ -1,14 +1,14 @@
 """Minimal context module for Sprint 3 context-aware alerting."""
 
+from PIL.Image import Image
 import torch
 import torch.nn.functional as F
 import torchvision.models as models
 import torchvision.transforms as T
-from PIL.Image import Image
 
 
 class ContextModule:
-    """Extracts scene tags from video frames without retraining."""
+    """Extracts security-relevant scene tags from video frames."""
 
     def __init__(self) -> None:
         """Initialize the ContextModule with pre-trained MobileNetV2."""
@@ -22,17 +22,32 @@ class ContextModule:
             T.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
         ])
 
+        # Semantycznie poprawne mapowanie klas pod monitoring (Addressing Łukasz's review)
         self.context_map = {
-            "outdoor": range(400, 900),
-            "indoor": range(0, 400),
-            "vehicle_setting": range(900, 1000),
+            "outdoor": [
+                919, 920, # Street sign, traffic light
+                673, 555, # Mouse (picket fence), fence
+                970, 971, # Alp, valley (landscape)
+                704, 705  # Parking meter, park bench
+            ],
+            "indoor": [
+                498, 500, # Cinema, home theater
+                508, 603, # Computer desk, heater
+                724, 743, # Office, prison
+                849, 850  # Store, sliding door
+            ],
+            "vehicle_setting": [
+                817, 511, # Bus, car
+                407, 751, # Ambulance, racer
+                654, 656  # Minibus, minivan
+            ]
         }
 
     def get_context(self, frame_tensor: Image) -> dict:
         """Extract context from a given frame.
 
         Args:
-            frame_tensor: PIL Image or Tensor frame.
+            frame_tensor: PIL Image.
 
         Returns:
             dict: Context output contract with scene_tag and confidence.

--- a/src/inference/mp4_cli.py
+++ b/src/inference/mp4_cli.py
@@ -4,10 +4,13 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from PIL import Image
 
 import torch
 import yaml
+import cv2
 
+from src.inference.context_adapter import ContextModule
 from src.inference.engine import InferenceEngine, InferenceResult
 from src.inference.json_writer import ActionEventWriter
 from src.inference.offline_runtime import run_video
@@ -120,12 +123,27 @@ def run_mp4_to_json_action_inference(request: InferenceCliRequest) -> int:
         model=model_adapter,
     )
 
-    _, _, inference_results,_ = run_video(str(request.input_path), engine=engine)
+    result = run_video(str(request.input_path), engine=engine)
+    inference_results = result[2] 
+    
     inference_results = _expand_batched_inference_results(inference_results)
     track_ids = build_track_ids(inference_results, settings.default_track_id)
 
     writer = ActionEventWriter(class_labels=settings.class_labels)
     writer.add_results(inference_results, track_ids=track_ids)
+
+    cap = cv2.VideoCapture(str(request.input_path))
+    ret, frame = cap.read()
+    cap.release()
+    
+    if ret:
+        rgb_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        pil_frame = Image.fromarray(rgb_frame)
+        
+        context_data = ContextModule().get_context(pil_frame)
+        
+        for event in writer.get_log().events:
+            event.context = context_data
 
     request.output_path.parent.mkdir(parents=True, exist_ok=True)
     writer.save(str(request.output_path))

--- a/src/inference/mp4_cli.py
+++ b/src/inference/mp4_cli.py
@@ -4,11 +4,11 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-from PIL import Image
 
+import cv2
 import torch
 import yaml
-import cv2
+from PIL import Image
 
 from src.inference.context_adapter import ContextModule
 from src.inference.engine import InferenceEngine, InferenceResult

--- a/src/inference/mp4_cli.py
+++ b/src/inference/mp4_cli.py
@@ -8,7 +8,6 @@ from typing import Any
 import cv2
 import torch
 import yaml
-from PIL import Image
 
 from src.inference.context_adapter import ContextModule
 from src.inference.engine import InferenceEngine, InferenceResult

--- a/src/inference/mp4_cli.py
+++ b/src/inference/mp4_cli.py
@@ -110,6 +110,13 @@ def run_mp4_to_json_action_inference(request: InferenceCliRequest) -> int:
         cli_device=request.device,
         config_device=settings.device,
     )
+
+    context_module = None
+    try:
+        context_module = ContextModule()
+    except Exception as e:
+        logger.warning("ContextModule failed to initialize: %s", e)
+
     model = load_model_from_checkpoint(request.checkpoint_path, device)
 
     tensorizer = FrameTensorizer(target_resolution=settings.target_resolution)
@@ -135,13 +142,17 @@ def run_mp4_to_json_action_inference(request: InferenceCliRequest) -> int:
     cap = cv2.VideoCapture(str(request.input_path))
     ret, frame = cap.read()
     cap.release()
+
+    context_data = {"scene_tag": "unknown", "confidence": 0.0}
     
-    if ret:
-        rgb_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-        pil_frame = Image.fromarray(rgb_frame)
-        
-        context_data = ContextModule().get_context(pil_frame)
-        
+    if ret and context_module:
+        try:
+            rgb_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            pil_frame = Image.fromarray(rgb_frame)            
+            context_data = context_module.get_context(pil_frame)
+        except Exception as e:
+            logger.error("Context inference failed: %s", e)
+
         for event in writer.get_log().events:
             event.context = context_data
 

--- a/src/inference/mp4_cli.py
+++ b/src/inference/mp4_cli.py
@@ -145,16 +145,15 @@ def run_mp4_to_json_action_inference(request: InferenceCliRequest) -> int:
 
     context_data = {"scene_tag": "unknown", "confidence": 0.0}
     
-    if ret and context_module:
+    if context_module and inference_results:
         try:
-            rgb_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-            pil_frame = Image.fromarray(rgb_frame)            
-            context_data = context_module.get_context(pil_frame)
-        except Exception as e:
-            logger.error("Context inference failed: %s", e)
+            first_frame = inference_results[0].window[0]
+            context_data = context_module.get_context(first_frame)
+        except (IndexError, TypeError, RuntimeError) as e:
+            logger.error("Context inference failed, using fallback: %s", e)
 
-        for event in writer.get_log().events:
-            event.context = context_data
+    for event in writer.get_log().events:
+        event.context = context_data
 
     request.output_path.parent.mkdir(parents=True, exist_ok=True)
     writer.save(str(request.output_path))

--- a/tests/inference/test_context.py
+++ b/tests/inference/test_context.py
@@ -1,0 +1,13 @@
+"""Local verification for Context Module determinism."""
+from src.inference.context_adapter import ContextModule
+from PIL import Image
+
+def test_context_determinism():
+    module = ContextModule()
+    fake_frame = Image.new('RGB', (224, 224), color=(128, 128, 128))
+    
+    res1 = module.get_context(fake_frame)
+    res2 = module.get_context(fake_frame)
+    
+    assert res1["scene_tag"] == res2["scene_tag"]
+    assert res1["confidence"] == res2["confidence"]

--- a/tests/inference/test_context.py
+++ b/tests/inference/test_context.py
@@ -1,8 +1,12 @@
 """Local verification for Context Module determinism."""
-from src.inference.context_adapter import ContextModule
+
 from PIL import Image
 
-def test_context_determinism():
+from src.inference.context_adapter import ContextModule
+
+
+def test_context_determinism() -> None:
+    """Verify that the module returns deterministic context outputs."""
     module = ContextModule()
     fake_frame = Image.new('RGB', (224, 224), color=(128, 128, 128))
     


### PR DESCRIPTION
# [Feature] Sprint 3 Minimal Context Module

## Summary
Implemented the minimal context module using a zero-shot classification approach (MobileNetV2) to extract scene tags without retraining the baseline action-recognition model.

The integration was done cleanly in `mp4_cli.py` to ensure the core multi-threaded inference pipeline is not blocked, and the schema in `action_event.py` was extended to formally support the context metadata contract.

## Checklist (DoD)
- [x] Minimal context module implemented
- [x] Context output format is explicit and documented (`action_event.py` & `docs/inference.md`)
- [x] Local verification exists for selected inputs or fixtures (`tests/inference/test_context.py`)
- [x] Integration assumptions for alerting are documented
- [x] PR created and linked to this issue

Closes #84