### PR TITLE
71 feature refactor offline mp4 runtime into reusable inference service

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -39,6 +39,35 @@ If neither is provided, `src.main` runs startup summary mode.
 5. Convert `InferenceResult` objects to `ActionEvent` records.
 6. Save action log JSON with `ActionEventWriter`.
 
+## Reusable service entrypoint
+
+For programmatic integrations (for example upcoming backend routes), use the
+service API instead of the CLI wrapper:
+
+```python
+from pathlib import Path
+
+from src.inference.service import InferenceServiceRequest, run_offline_mp4_inference
+
+result = run_offline_mp4_inference(
+    InferenceServiceRequest(
+        video_path=Path("data/raw/walking/sample.mp4"),
+        checkpoint_path=Path("data/logs/checkpoints/baseline_epoch_10.pth"),
+        config_path=Path("configs/data_pipeline.yml"),
+        device="auto",
+    )
+)
+
+print(result.frame_count, result.inference_count, result.event_count)
+```
+
+The service returns a typed in-memory result with:
+- processed frame count
+- inference window count
+- expanded `InferenceResult` items
+- generated `ActionEvent` records
+- resolved runtime settings and selected torch device
+
 ### Offline runtime details
 
 The offline runtime processes video frames using a producer-consumer pattern:

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -68,6 +68,9 @@ The service returns a typed in-memory result with:
 - generated `ActionEvent` records
 - resolved runtime settings and selected torch device
 
+`run_mp4_to_json_action_inference` (CLI wrapper) now delegates runtime execution to
+this service entrypoint and handles only output-file serialization.
+
 ### Offline runtime details
 
 The offline runtime processes video frames using a producer-consumer pattern:

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -71,6 +71,11 @@ The service returns a typed in-memory result with:
 `run_mp4_to_json_action_inference` (CLI wrapper) now delegates runtime execution to
 this service entrypoint and handles only output-file serialization.
 
+Shared runtime primitives are implemented in `src/inference/runtime.py` and reused
+by both the service and CLI layers (`load_runtime_settings`, device resolution,
+checkpoint loading, `WindowModelAdapter`, track-id building, and
+`expand_batched_inference_results`).
+
 ### Offline runtime details
 
 The offline runtime processes video frames using a producer-consumer pattern:

--- a/src/inference/__init__.py
+++ b/src/inference/__init__.py
@@ -3,6 +3,11 @@
 from src.inference.action_event import ActionEvent, ActionEventLog
 from src.inference.engine import InferenceEngine, InferenceResult
 from src.inference.json_writer import ActionEventWriter
+from src.inference.service import (
+    InferenceServiceRequest,
+    InferenceServiceResult,
+    run_offline_mp4_inference,
+)
 
 __all__ = [
     "ActionEvent",
@@ -10,4 +15,7 @@ __all__ = [
     "ActionEventWriter",
     "InferenceEngine",
     "InferenceResult",
+    "InferenceServiceRequest",
+    "InferenceServiceResult",
+    "run_offline_mp4_inference",
 ]

--- a/src/inference/mp4_cli.py
+++ b/src/inference/mp4_cli.py
@@ -3,16 +3,18 @@
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
-import torch
-import yaml
-
-from src.inference.engine import InferenceResult
 from src.inference.json_writer import ActionEventWriter
-from src.inference.tensorize import FrameTensorizer
-from src.models.baseline import BaselineBehaviorModel
-from src.models.dummy import DummyBehaviorModel
+from src.inference.runtime import (
+    InferenceRuntimeSettings,
+    WindowModelAdapter,
+    build_track_ids,
+    expand_batched_inference_results,
+    load_model_from_checkpoint,
+    load_runtime_settings,
+    resolve_inference_device,
+)
+from src.inference.service import InferenceServiceRequest, run_offline_mp4_inference
 
 logger = logging.getLogger(__name__)
 
@@ -28,71 +30,6 @@ class InferenceCliRequest:
     device: str | None = None
 
 
-@dataclass(frozen=True)
-class InferenceRuntimeSettings:
-    """Typed runtime settings parsed from YAML config."""
-
-    target_resolution: tuple[int, int]
-    window_size: int
-    stride: int
-    class_labels: list[str]
-    default_track_id: int | None
-    device: str | None
-
-
-class WindowModelAdapter:
-    """Adapter that tensorizes frame windows before calling a torch model."""
-
-    def __init__(
-        self,
-        model: torch.nn.Module,
-        tensorizer: FrameTensorizer,
-        device: torch.device,
-    ) -> None:
-        """Initialize the adapter with a model, tensorizer, and target device."""
-        has_predict = callable(getattr(model, "predict", None))
-        # model does not have to be nn.Module
-        if not callable(model) and not has_predict:
-            raise TypeError("model must be callable or expose predict(tensor)")
-        if not isinstance(tensorizer, FrameTensorizer):
-            raise TypeError("tensorizer must be a FrameTensorizer instance")
-        if not isinstance(device, torch.device):
-            raise TypeError("device must be a torch.device instance")
-
-        self._model = model
-        self._tensorizer = tensorizer
-        self._device = device
-
-    def __call__(self, window: tuple[Any, ...]) -> torch.Tensor:
-        """Run model inference on a frame window and return logits/probabilities."""
-        if not isinstance(window, tuple):
-            raise TypeError("window must be a tuple of frames")
-        if len(window) == 0:
-            raise ValueError("window cannot be empty")
-
-        tensor = self._tensorizer.tensorize(list(window)).to(self._device)
-        with torch.no_grad():
-            if callable(self._model):
-                output = self._model(tensor)
-            else:
-                output = self._model.predict(tensor)
-
-        if not isinstance(output, torch.Tensor):
-            raise TypeError("model output must be a torch.Tensor")
-
-        if output.ndim == 1:
-            return output.detach().cpu()
-
-        # warning: in the future, there will be bug caused by ignoring other batch
-        if output.ndim == 2:
-            if output.shape[0] < 1:
-                raise ValueError(
-                    "model output batch dimension must not be empty")
-            return output.detach().cpu()
-
-        raise ValueError("model output tensor must be 1D or 2D")
-
-
 def run_mp4_to_json_action_inference(request: InferenceCliRequest) -> int:
     """Run end-to-end MP4 inference and save ActionEvent log as JSON."""
     if not isinstance(request, InferenceCliRequest):
@@ -100,11 +37,6 @@ def run_mp4_to_json_action_inference(request: InferenceCliRequest) -> int:
     _validate_request_paths(request)
     if request.input_path.suffix.lower() != ".mp4":
         raise ValueError("input_path must point to an .mp4 file")
-
-    from src.inference.service import (
-        InferenceServiceRequest,
-        run_offline_mp4_inference,
-    )
 
     service_result = run_offline_mp4_inference(
         InferenceServiceRequest(
@@ -130,174 +62,12 @@ def run_mp4_to_json_action_inference(request: InferenceCliRequest) -> int:
     return 0
 
 
-def load_runtime_settings(config_path: Path) -> InferenceRuntimeSettings:
-    """Load and validate inference runtime settings from YAML config."""
-    if not isinstance(config_path, Path):
-        raise TypeError("config_path must be a pathlib.Path instance")
-    if not config_path.exists():
-        raise FileNotFoundError(f"Config file not found: {config_path}")
-    if not config_path.is_file():
-        # found but it is not a file
-        raise ValueError(f"Config path must point to a file: {config_path}")
-
-    with config_path.open("r", encoding="utf-8") as config_file:
-        raw_config = yaml.safe_load(config_file)
-
-    if raw_config is None:
-        raw_config = {}
-    if not isinstance(raw_config, dict):
-        raise TypeError("Config root must be a mapping/object")
-
-    pipeline_cfg = _ensure_mapping(raw_config.get("pipeline", {}), "pipeline")
-    inference_cfg = _ensure_mapping(
-        raw_config.get("inference", {}), "inference")
-    tracking_cfg = _ensure_mapping(raw_config.get("tracking", {}), "tracking")
-
-    target_resolution = _parse_target_resolution(
-        pipeline_cfg.get("target_resolution", (224, 224)),
-    )
-    window_size = _parse_positive_int(
-        pipeline_cfg.get("temporal_window", 16),
-        "pipeline.temporal_window",
-    )
-    stride = _parse_positive_int(
-        inference_cfg.get("stride", 1),
-        "inference.stride",
-    )
-    class_labels = _parse_class_labels(inference_cfg.get("class_labels"))
-    default_track_id = _parse_optional_track_id(
-        tracking_cfg.get("default_track_id"))
-    device = _parse_optional_device(
-        inference_cfg.get("device"), "inference.device")
-
-    return InferenceRuntimeSettings(
-        target_resolution=target_resolution,
-        window_size=window_size,
-        stride=stride,
-        class_labels=class_labels,
-        default_track_id=default_track_id,
-        device=device,
-    )
-
-
-def load_model_from_checkpoint(
-    checkpoint_path: Path,
-    device: torch.device,
-) -> torch.nn.Module:
-    """Load a model from checkpoint and move it to the target device."""
-    if not isinstance(checkpoint_path, Path):
-        raise TypeError("checkpoint_path must be a pathlib.Path instance")
-    if not isinstance(device, torch.device):
-        raise TypeError("device must be a torch.device instance")
-    if not checkpoint_path.exists():
-        raise FileNotFoundError(
-            f"Checkpoint file not found: {checkpoint_path}")
-    if not checkpoint_path.is_file():
-        raise ValueError(
-            f"Checkpoint path must point to a file: {checkpoint_path}")
-
-    raw_checkpoint = torch.load(
-        # against Arbitrary Code Execution
-        str(checkpoint_path), map_location=device, weights_only=True)
-    if not isinstance(raw_checkpoint, dict):
-        raise TypeError("Checkpoint must contain a mapping/object payload")
-
-    raw_state_dict = raw_checkpoint.get("model_state_dict", raw_checkpoint)
-    state_dict = _validate_state_dict(raw_state_dict)
-    num_classes = _infer_num_classes(state_dict)
-
-    model_name = raw_checkpoint.get("model_name")
-    if model_name is not None and not isinstance(model_name, str):
-        raise TypeError(
-            "model_name in checkpoint must be a string when provided")
-
-    candidates = _resolve_model_candidates(model_name)
-    errors: list[str] = []
-    for candidate in candidates:
-        model = _build_model(candidate, num_classes)
-        try:
-            model.load_state_dict(state_dict, strict=True)
-        except RuntimeError as runtime_error:
-            errors.append(f"{candidate}: {runtime_error}")
-            continue
-
-        model.to(device)
-        model.eval()
-        return model
-
-    joined_errors = "; ".join(errors)
-    raise ValueError(
-        "Could not load checkpoint into a supported model architecture. "
-        f"Attempted: {', '.join(candidates)}. Details: {joined_errors}",
-    )
-
-
-def build_track_ids(
-    results: list[InferenceResult],
-    default_track_id: int | None,
-) -> list[int | None]:
-    """Build per-result tracking IDs used by ActionEventWriter."""
-    if not isinstance(results, list):
-        raise TypeError("results must be a list of InferenceResult objects")
-    if default_track_id is not None and (
-        not isinstance(default_track_id, int) or isinstance(
-            default_track_id, bool)
-    ):
-        raise TypeError("default_track_id must be an integer or None")
-    if isinstance(default_track_id, int) and default_track_id < 0:
-        raise ValueError("default_track_id must be >= 0")
-
-    for result in results:
-        if not isinstance(result, InferenceResult):
-            raise TypeError(
-                "results must only contain InferenceResult objects")
-
-    if default_track_id is None:
-        return [None] * len(results)
-    return [default_track_id] * len(results)
-
-
-def _expand_batched_inference_results(
-    results: list[InferenceResult],
-) -> list[InferenceResult]:
-    """Expand 2D tensor predictions (batch, classes) into per-item results."""
-    expanded_results: list[InferenceResult] = []
-    for result in results:
-        prediction = result.prediction
-        if isinstance(prediction, torch.Tensor) and prediction.ndim == 2:
-            if prediction.shape[0] < 1:
-                raise ValueError(
-                    "model output batch dimension must not be empty")
-            for item_prediction in prediction:
-                expanded_results.append(
-                    InferenceResult(
-                        window=result.window,
-                        start_frame_index=result.start_frame_index,
-                        end_frame_index=result.end_frame_index,
-                        start_timestamp=result.start_timestamp,
-                        end_timestamp=result.end_timestamp,
-                        prediction=item_prediction,
-                    )
-                )
-            continue
-        expanded_results.append(result)
-    return expanded_results
-
-
-def _ensure_mapping(value: object, field_name: str) -> dict[str, Any]:
-    """Ensure value is a dictionary-like mapping represented as dict."""
-    if not isinstance(value, dict):
-        raise TypeError(f"{field_name} must be a mapping/object")
-    return value
-
-
 def _validate_request_paths(request: InferenceCliRequest) -> None:
     """Validate that request fields are Path objects."""
     if not isinstance(request.input_path, Path):
         raise TypeError("request.input_path must be a pathlib.Path instance")
     if not isinstance(request.checkpoint_path, Path):
-        raise TypeError(
-            "request.checkpoint_path must be a pathlib.Path instance")
+        raise TypeError("request.checkpoint_path must be a pathlib.Path instance")
     if not isinstance(request.config_path, Path):
         raise TypeError("request.config_path must be a pathlib.Path instance")
     if not isinstance(request.output_path, Path):
@@ -306,167 +76,5 @@ def _validate_request_paths(request: InferenceCliRequest) -> None:
         raise TypeError("request.device must be a string or None")
 
 
-def _parse_positive_int(value: object, field_name: str) -> int:
-    """Parse a positive integer while rejecting booleans."""
-    if not isinstance(value, int) or isinstance(value, bool):  # bool inherit from int
-        raise TypeError(f"{field_name} must be an integer")
-    if value <= 0:
-        raise ValueError(f"{field_name} must be > 0")
-    return value
-
-
-def _parse_target_resolution(value: object) -> tuple[int, int]:
-    """Parse and validate target resolution as (width, height)."""
-    if not isinstance(value, (list, tuple)):
-        raise TypeError(
-            "pipeline.target_resolution must be a list/tuple of two integers")
-    if len(value) != 2:
-        raise ValueError(
-            "pipeline.target_resolution must contain exactly 2 values")
-
-    width = _parse_positive_int(value[0], "pipeline.target_resolution[0]")
-    height = _parse_positive_int(value[1], "pipeline.target_resolution[1]")
-    return (width, height)
-
-
-def _parse_class_labels(value: object) -> list[str]:
-    """Parse optional class labels list."""
-    if value is None:
-        return []
-    if not isinstance(value, list):
-        raise TypeError("inference.class_labels must be a list of strings")
-
-    class_labels: list[str] = []
-    for label in value:
-        if not isinstance(label, str):
-            raise TypeError("inference.class_labels must contain only strings")
-        if not label.strip():
-            raise ValueError(
-                "inference.class_labels must not contain empty strings")
-        class_labels.append(label)
-    return class_labels
-
-
-def _parse_optional_track_id(value: object) -> int | None:
-    """Parse optional default track ID."""
-    if value is None:
-        return None
-    if not isinstance(value, int) or isinstance(value, bool):
-        raise TypeError("tracking.default_track_id must be an integer or null")
-    if value < 0:
-        raise ValueError("tracking.default_track_id must be >= 0")
-    return value
-
-
-def _parse_optional_device(value: object, field_name: str) -> str | None:
-    """Parse optional inference device override."""
-    if value is None:
-        return None
-    if not isinstance(value, str):
-        raise TypeError(f"{field_name} must be one of: auto, cpu, cuda, mps")
-    normalized = value.strip().lower()
-    if normalized not in {"auto", "cpu", "cuda", "mps"}:
-        raise ValueError(f"{field_name} must be one of: auto, cpu, cuda, mps")
-    return normalized
-
-
-def resolve_inference_device(
-    cli_device: str | None,
-    config_device: str | None,
-) -> torch.device:
-    """Resolve torch device from CLI/config overrides and available backends."""
-    cli_choice = _parse_optional_device(cli_device, "request.device")
-    config_choice = _parse_optional_device(config_device, "inference.device")
-    preferred_device = cli_choice if cli_choice is not None else config_choice
-
-    if preferred_device in {None, "auto"}:
-        if torch.cuda.is_available():
-            return torch.device("cuda")
-        if _is_mps_available():
-            return torch.device("mps")
-        return torch.device("cpu")
-
-    if preferred_device == "cpu":
-        return torch.device("cpu")
-
-    if preferred_device == "cuda":
-        if not torch.cuda.is_available():
-            raise ValueError(
-                "CUDA device requested but not available on this machine",
-            )
-        return torch.device("cuda")
-
-    if preferred_device == "mps":
-        if not _is_mps_available():
-            raise ValueError(
-                "MPS device requested but not available on this machine",
-            )
-        return torch.device("mps")
-
-    raise ValueError(f"Unsupported device selection: {preferred_device}")
-
-
-def _is_mps_available() -> bool:
-    """Return True when torch MPS backend is available."""
-    mps_backend = getattr(torch.backends, "mps", None)
-    if mps_backend is None or not hasattr(mps_backend, "is_available"):
-        return False
-    return bool(mps_backend.is_available())
-
-
-def _validate_state_dict(value: object) -> dict[str, torch.Tensor]:
-    """Validate and normalize checkpoint state_dict."""
-    if not isinstance(value, dict):
-        raise TypeError("model_state_dict must be a mapping/object")
-    if len(value) == 0:
-        raise ValueError("model_state_dict must not be empty")
-
-    normalized: dict[str, torch.Tensor] = {}
-    for key, tensor in value.items():
-        if not isinstance(key, str):
-            raise TypeError("model_state_dict keys must be strings")
-        if not isinstance(tensor, torch.Tensor):
-            raise TypeError(
-                "model_state_dict values must be torch.Tensor objects")
-        normalized[key] = tensor
-    return normalized
-
-
-# checpoint file does not contain class count
-def _infer_num_classes(state_dict: dict[str, torch.Tensor]) -> int:
-    """Infer output class count from fc.weight shape."""
-    key_candidates = ("model.fc.weight", "fc.weight")
-    for key in key_candidates:
-        maybe_weight = state_dict.get(key)
-        if maybe_weight is None:
-            continue
-        if not isinstance(maybe_weight, torch.Tensor):
-            raise TypeError(f"{key} must be a torch.Tensor")
-        if maybe_weight.ndim != 2:
-            raise ValueError(f"{key} must be a rank-2 tensor")
-        return int(maybe_weight.shape[0])
-
-    raise ValueError(
-        "Could not infer number of classes from checkpoint. "
-        "Expected key 'model.fc.weight' or 'fc.weight'.",
-    )
-
-
-def _resolve_model_candidates(model_name: str | None) -> list[str]:
-    """Resolve model loading order from optional model_name metadata."""
-    if model_name is None:
-        return ["baseline", "dummy"]
-
-    normalized_name = model_name.strip().lower()
-    if normalized_name not in {"baseline", "dummy"}:
-        raise ValueError("model_name must be either 'baseline' or 'dummy'")
-    return [normalized_name]
-
-
-def _build_model(model_name: str, num_classes: int) -> torch.nn.Module:
-    """Build a supported model instance by name."""
-    if model_name == "baseline":
-        return BaselineBehaviorModel(num_classes=num_classes)
-    if model_name == "dummy":
-        return DummyBehaviorModel(num_classes=num_classes)
-    raise ValueError(f"Unsupported model name: {model_name}")
+# Backward-compatible private alias while shared runtime helper is now public.
+_expand_batched_inference_results = expand_batched_inference_results

--- a/src/inference/mp4_cli.py
+++ b/src/inference/mp4_cli.py
@@ -8,9 +8,8 @@ from typing import Any
 import torch
 import yaml
 
-from src.inference.engine import InferenceEngine, InferenceResult
+from src.inference.engine import InferenceResult
 from src.inference.json_writer import ActionEventWriter
-from src.inference.offline_runtime import run_video
 from src.inference.tensorize import FrameTensorizer
 from src.models.baseline import BaselineBehaviorModel
 from src.models.dummy import DummyBehaviorModel
@@ -102,36 +101,29 @@ def run_mp4_to_json_action_inference(request: InferenceCliRequest) -> int:
     if request.input_path.suffix.lower() != ".mp4":
         raise ValueError("input_path must point to an .mp4 file")
 
-    settings = load_runtime_settings(request.config_path)
-    device = resolve_inference_device(
-        cli_device=request.device,
-        config_device=settings.device,
-    )
-    model = load_model_from_checkpoint(request.checkpoint_path, device)
-
-    tensorizer = FrameTensorizer(target_resolution=settings.target_resolution)
-    model_adapter = WindowModelAdapter(
-        model=model, tensorizer=tensorizer, device=device)
-
-    # initializing of engine in this place is more flexible than in the run_video()
-    engine = InferenceEngine(
-        window_size=settings.window_size,
-        stride=settings.stride,
-        model=model_adapter,
+    from src.inference.service import (
+        InferenceServiceRequest,
+        run_offline_mp4_inference,
     )
 
-    _, _, inference_results,_ = run_video(str(request.input_path), engine=engine)
-    inference_results = _expand_batched_inference_results(inference_results)
-    track_ids = build_track_ids(inference_results, settings.default_track_id)
-
-    writer = ActionEventWriter(class_labels=settings.class_labels)
-    writer.add_results(inference_results, track_ids=track_ids)
+    service_result = run_offline_mp4_inference(
+        InferenceServiceRequest(
+            video_path=request.input_path,
+            checkpoint_path=request.checkpoint_path,
+            config_path=request.config_path,
+            device=request.device,
+        )
+    )
 
     request.output_path.parent.mkdir(parents=True, exist_ok=True)
+    writer = ActionEventWriter(
+        class_labels=service_result.runtime_settings.class_labels,
+    )
+    writer.get_log().add_events(list(service_result.action_events))
     writer.save(str(request.output_path))
     logger.info(
         "[OK] Wrote %d action events to: %s",
-        len(writer.get_log().events),
+        service_result.event_count,
         request.output_path,
     )
 

--- a/src/inference/mp4_cli.py
+++ b/src/inference/mp4_cli.py
@@ -4,16 +4,8 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 
+from src.inference import runtime as runtime_primitives
 from src.inference.json_writer import ActionEventWriter
-from src.inference.runtime import (
-    InferenceRuntimeSettings,
-    WindowModelAdapter,
-    build_track_ids,
-    expand_batched_inference_results,
-    load_model_from_checkpoint,
-    load_runtime_settings,
-    resolve_inference_device,
-)
 from src.inference.service import InferenceServiceRequest, run_offline_mp4_inference
 
 logger = logging.getLogger(__name__)
@@ -77,4 +69,11 @@ def _validate_request_paths(request: InferenceCliRequest) -> None:
 
 
 # Backward-compatible private alias while shared runtime helper is now public.
+InferenceRuntimeSettings = runtime_primitives.InferenceRuntimeSettings
+WindowModelAdapter = runtime_primitives.WindowModelAdapter
+build_track_ids = runtime_primitives.build_track_ids
+expand_batched_inference_results = runtime_primitives.expand_batched_inference_results
+load_model_from_checkpoint = runtime_primitives.load_model_from_checkpoint
+load_runtime_settings = runtime_primitives.load_runtime_settings
+resolve_inference_device = runtime_primitives.resolve_inference_device
 _expand_batched_inference_results = expand_batched_inference_results

--- a/src/inference/offline_runtime.py
+++ b/src/inference/offline_runtime.py
@@ -88,7 +88,8 @@ def consume_frame_queue(frame_queue: Queue, engine: InferenceEngine, stats: dict
 def run_video(
     video_path: str,
     engine: Optional[InferenceEngine] = None,
-    tracker: Optional[BaseTracker] = None
+    tracker: Optional[BaseTracker] = None,
+    emit_runtime_summary: bool = True,
 ) -> tuple[int, int, list[Any], list[Any]]:
     """Runs offline inference on a single video file.
 
@@ -97,6 +98,7 @@ def run_video(
         engine: Optional inference engine instance. If None, a default
             InferenceEngine is created.
         tracker: Optional tracker used to assign track IDs to inference results.
+        emit_runtime_summary: Whether to print processed frame/window/event stats.
 
     Returns:
         tuple[int, int, list[Any], list[Any]]: Number of processed frames,
@@ -142,8 +144,9 @@ def run_video(
     writer.add_results(inference_results, track_ids=track_ids)
     action_events = writer.get_log().events
 
-    print(f"Processed {frame_count} frames")
-    print(f"Generated {inference_count} inference windows")
-    print(f"Generated {len(action_events)} action events")
+    if emit_runtime_summary:
+        print(f"Processed {frame_count} frames")
+        print(f"Generated {inference_count} inference windows")
+        print(f"Generated {len(action_events)} action events")
 
     return frame_count, inference_count, inference_results, action_events

--- a/src/inference/runtime.py
+++ b/src/inference/runtime.py
@@ -1,0 +1,396 @@
+"""Shared runtime primitives for offline MP4 inference."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+import yaml
+
+from src.inference.engine import InferenceResult
+from src.inference.tensorize import FrameTensorizer
+from src.models.baseline import BaselineBehaviorModel
+from src.models.dummy import DummyBehaviorModel
+
+
+@dataclass(frozen=True)
+class InferenceRuntimeSettings:
+    """Typed runtime settings parsed from YAML config."""
+
+    target_resolution: tuple[int, int]
+    window_size: int
+    stride: int
+    class_labels: list[str]
+    default_track_id: int | None
+    device: str | None
+
+
+class WindowModelAdapter:
+    """Adapter that tensorizes frame windows before calling a torch model."""
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        tensorizer: FrameTensorizer,
+        device: torch.device,
+    ) -> None:
+        """Initialize the adapter with a model, tensorizer, and target device."""
+        has_predict = callable(getattr(model, "predict", None))
+        if not callable(model) and not has_predict:
+            raise TypeError("model must be callable or expose predict(tensor)")
+        if not isinstance(tensorizer, FrameTensorizer):
+            raise TypeError("tensorizer must be a FrameTensorizer instance")
+        if not isinstance(device, torch.device):
+            raise TypeError("device must be a torch.device instance")
+
+        self._model = model
+        self._tensorizer = tensorizer
+        self._device = device
+
+    def __call__(self, window: tuple[Any, ...]) -> torch.Tensor:
+        """Run model inference on a frame window and return logits/probabilities."""
+        if not isinstance(window, tuple):
+            raise TypeError("window must be a tuple of frames")
+        if len(window) == 0:
+            raise ValueError("window cannot be empty")
+
+        tensor = self._tensorizer.tensorize(list(window)).to(self._device)
+        with torch.no_grad():
+            if callable(self._model):
+                output = self._model(tensor)
+            else:
+                output = self._model.predict(tensor)
+
+        if not isinstance(output, torch.Tensor):
+            raise TypeError("model output must be a torch.Tensor")
+
+        if output.ndim == 1:
+            return output.detach().cpu()
+
+        if output.ndim == 2:
+            if output.shape[0] < 1:
+                raise ValueError("model output batch dimension must not be empty")
+            return output.detach().cpu()
+
+        raise ValueError("model output tensor must be 1D or 2D")
+
+
+def load_runtime_settings(config_path: Path) -> InferenceRuntimeSettings:
+    """Load and validate inference runtime settings from YAML config."""
+    if not isinstance(config_path, Path):
+        raise TypeError("config_path must be a pathlib.Path instance")
+    if not config_path.exists():
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+    if not config_path.is_file():
+        raise ValueError(f"Config path must point to a file: {config_path}")
+
+    with config_path.open("r", encoding="utf-8") as config_file:
+        raw_config = yaml.safe_load(config_file)
+
+    if raw_config is None:
+        raw_config = {}
+    if not isinstance(raw_config, dict):
+        raise TypeError("Config root must be a mapping/object")
+
+    pipeline_cfg = _ensure_mapping(raw_config.get("pipeline", {}), "pipeline")
+    inference_cfg = _ensure_mapping(raw_config.get("inference", {}), "inference")
+    tracking_cfg = _ensure_mapping(raw_config.get("tracking", {}), "tracking")
+
+    target_resolution = _parse_target_resolution(
+        pipeline_cfg.get("target_resolution", (224, 224)),
+    )
+    window_size = _parse_positive_int(
+        pipeline_cfg.get("temporal_window", 16),
+        "pipeline.temporal_window",
+    )
+    stride = _parse_positive_int(
+        inference_cfg.get("stride", 1),
+        "inference.stride",
+    )
+    class_labels = _parse_class_labels(inference_cfg.get("class_labels"))
+    default_track_id = _parse_optional_track_id(tracking_cfg.get("default_track_id"))
+    device = _parse_optional_device(inference_cfg.get("device"), "inference.device")
+
+    return InferenceRuntimeSettings(
+        target_resolution=target_resolution,
+        window_size=window_size,
+        stride=stride,
+        class_labels=class_labels,
+        default_track_id=default_track_id,
+        device=device,
+    )
+
+
+def load_model_from_checkpoint(
+    checkpoint_path: Path,
+    device: torch.device,
+) -> torch.nn.Module:
+    """Load a model from checkpoint and move it to the target device."""
+    if not isinstance(checkpoint_path, Path):
+        raise TypeError("checkpoint_path must be a pathlib.Path instance")
+    if not isinstance(device, torch.device):
+        raise TypeError("device must be a torch.device instance")
+    if not checkpoint_path.exists():
+        raise FileNotFoundError(f"Checkpoint file not found: {checkpoint_path}")
+    if not checkpoint_path.is_file():
+        raise ValueError(f"Checkpoint path must point to a file: {checkpoint_path}")
+
+    raw_checkpoint = torch.load(
+        str(checkpoint_path),
+        map_location=device,
+        weights_only=True,
+    )
+    if not isinstance(raw_checkpoint, dict):
+        raise TypeError("Checkpoint must contain a mapping/object payload")
+
+    raw_state_dict = raw_checkpoint.get("model_state_dict", raw_checkpoint)
+    state_dict = _validate_state_dict(raw_state_dict)
+    num_classes = _infer_num_classes(state_dict)
+
+    model_name = raw_checkpoint.get("model_name")
+    if model_name is not None and not isinstance(model_name, str):
+        raise TypeError("model_name in checkpoint must be a string when provided")
+
+    candidates = _resolve_model_candidates(model_name)
+    errors: list[str] = []
+    for candidate in candidates:
+        model = _build_model(candidate, num_classes)
+        try:
+            model.load_state_dict(state_dict, strict=True)
+        except RuntimeError as runtime_error:
+            errors.append(f"{candidate}: {runtime_error}")
+            continue
+
+        model.to(device)
+        model.eval()
+        return model
+
+    joined_errors = "; ".join(errors)
+    raise ValueError(
+        "Could not load checkpoint into a supported model architecture. "
+        f"Attempted: {', '.join(candidates)}. Details: {joined_errors}",
+    )
+
+
+def build_track_ids(
+    results: list[InferenceResult],
+    default_track_id: int | None,
+) -> list[int | None]:
+    """Build per-result tracking IDs used by ActionEventWriter."""
+    if not isinstance(results, list):
+        raise TypeError("results must be a list of InferenceResult objects")
+    if default_track_id is not None and (
+        not isinstance(default_track_id, int) or isinstance(default_track_id, bool)
+    ):
+        raise TypeError("default_track_id must be an integer or None")
+    if isinstance(default_track_id, int) and default_track_id < 0:
+        raise ValueError("default_track_id must be >= 0")
+
+    for result in results:
+        if not isinstance(result, InferenceResult):
+            raise TypeError("results must only contain InferenceResult objects")
+
+    if default_track_id is None:
+        return [None] * len(results)
+    return [default_track_id] * len(results)
+
+
+def expand_batched_inference_results(
+    results: list[InferenceResult],
+) -> list[InferenceResult]:
+    """Expand 2D tensor predictions (batch, classes) into per-item results."""
+    expanded_results: list[InferenceResult] = []
+    for result in results:
+        prediction = result.prediction
+        if isinstance(prediction, torch.Tensor) and prediction.ndim == 2:
+            if prediction.shape[0] < 1:
+                raise ValueError("model output batch dimension must not be empty")
+            for item_prediction in prediction:
+                expanded_results.append(
+                    InferenceResult(
+                        window=result.window,
+                        start_frame_index=result.start_frame_index,
+                        end_frame_index=result.end_frame_index,
+                        start_timestamp=result.start_timestamp,
+                        end_timestamp=result.end_timestamp,
+                        prediction=item_prediction,
+                    )
+                )
+            continue
+        expanded_results.append(result)
+    return expanded_results
+
+
+def resolve_inference_device(
+    cli_device: str | None,
+    config_device: str | None,
+) -> torch.device:
+    """Resolve torch device from CLI/config overrides and available backends."""
+    cli_choice = _parse_optional_device(cli_device, "request.device")
+    config_choice = _parse_optional_device(config_device, "inference.device")
+    preferred_device = cli_choice if cli_choice is not None else config_choice
+
+    if preferred_device in {None, "auto"}:
+        if torch.cuda.is_available():
+            return torch.device("cuda")
+        if _is_mps_available():
+            return torch.device("mps")
+        return torch.device("cpu")
+
+    if preferred_device == "cpu":
+        return torch.device("cpu")
+
+    if preferred_device == "cuda":
+        if not torch.cuda.is_available():
+            raise ValueError("CUDA device requested but not available on this machine")
+        return torch.device("cuda")
+
+    if preferred_device == "mps":
+        if not _is_mps_available():
+            raise ValueError("MPS device requested but not available on this machine")
+        return torch.device("mps")
+
+    raise ValueError(f"Unsupported device selection: {preferred_device}")
+
+
+def _ensure_mapping(value: object, field_name: str) -> dict[str, Any]:
+    """Ensure value is a dictionary-like mapping represented as dict."""
+    if not isinstance(value, dict):
+        raise TypeError(f"{field_name} must be a mapping/object")
+    return value
+
+
+def _parse_positive_int(value: object, field_name: str) -> int:
+    """Parse a positive integer while rejecting booleans."""
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError(f"{field_name} must be an integer")
+    if value <= 0:
+        raise ValueError(f"{field_name} must be > 0")
+    return value
+
+
+def _parse_target_resolution(value: object) -> tuple[int, int]:
+    """Parse and validate target resolution as (width, height)."""
+    if not isinstance(value, (list, tuple)):
+        raise TypeError("pipeline.target_resolution must be a list/tuple of two integers")
+    if len(value) != 2:
+        raise ValueError("pipeline.target_resolution must contain exactly 2 values")
+
+    width = _parse_positive_int(value[0], "pipeline.target_resolution[0]")
+    height = _parse_positive_int(value[1], "pipeline.target_resolution[1]")
+    return (width, height)
+
+
+def _parse_class_labels(value: object) -> list[str]:
+    """Parse optional class labels list."""
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise TypeError("inference.class_labels must be a list of strings")
+
+    class_labels: list[str] = []
+    for label in value:
+        if not isinstance(label, str):
+            raise TypeError("inference.class_labels must contain only strings")
+        if not label.strip():
+            raise ValueError("inference.class_labels must not contain empty strings")
+        class_labels.append(label)
+    return class_labels
+
+
+def _parse_optional_track_id(value: object) -> int | None:
+    """Parse optional default track ID."""
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError("tracking.default_track_id must be an integer or null")
+    if value < 0:
+        raise ValueError("tracking.default_track_id must be >= 0")
+    return value
+
+
+def _parse_optional_device(value: object, field_name: str) -> str | None:
+    """Parse optional inference device override."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be one of: auto, cpu, cuda, mps")
+    normalized = value.strip().lower()
+    if normalized not in {"auto", "cpu", "cuda", "mps"}:
+        raise ValueError(f"{field_name} must be one of: auto, cpu, cuda, mps")
+    return normalized
+
+
+def _is_mps_available() -> bool:
+    """Return True when torch MPS backend is available."""
+    mps_backend = getattr(torch.backends, "mps", None)
+    if mps_backend is None or not hasattr(mps_backend, "is_available"):
+        return False
+    return bool(mps_backend.is_available())
+
+
+def _validate_state_dict(value: object) -> dict[str, torch.Tensor]:
+    """Validate and normalize checkpoint state_dict."""
+    if not isinstance(value, dict):
+        raise TypeError("model_state_dict must be a mapping/object")
+    if len(value) == 0:
+        raise ValueError("model_state_dict must not be empty")
+
+    normalized: dict[str, torch.Tensor] = {}
+    for key, tensor in value.items():
+        if not isinstance(key, str):
+            raise TypeError("model_state_dict keys must be strings")
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError("model_state_dict values must be torch.Tensor objects")
+        normalized[key] = tensor
+    return normalized
+
+
+def _infer_num_classes(state_dict: dict[str, torch.Tensor]) -> int:
+    """Infer output class count from fc.weight shape."""
+    key_candidates = ("model.fc.weight", "fc.weight")
+    for key in key_candidates:
+        maybe_weight = state_dict.get(key)
+        if maybe_weight is None:
+            continue
+        if not isinstance(maybe_weight, torch.Tensor):
+            raise TypeError(f"{key} must be a torch.Tensor")
+        if maybe_weight.ndim != 2:
+            raise ValueError(f"{key} must be a rank-2 tensor")
+        return int(maybe_weight.shape[0])
+
+    raise ValueError(
+        "Could not infer number of classes from checkpoint. "
+        "Expected key 'model.fc.weight' or 'fc.weight'.",
+    )
+
+
+def _resolve_model_candidates(model_name: str | None) -> list[str]:
+    """Resolve model loading order from optional model_name metadata."""
+    if model_name is None:
+        return ["baseline", "dummy"]
+
+    normalized_name = model_name.strip().lower()
+    if normalized_name not in {"baseline", "dummy"}:
+        raise ValueError("model_name must be either 'baseline' or 'dummy'")
+    return [normalized_name]
+
+
+def _build_model(model_name: str, num_classes: int) -> torch.nn.Module:
+    """Build a supported model instance by name."""
+    if model_name == "baseline":
+        return BaselineBehaviorModel(num_classes=num_classes)
+    if model_name == "dummy":
+        return DummyBehaviorModel(num_classes=num_classes)
+    raise ValueError(f"Unsupported model name: {model_name}")
+
+
+__all__ = [
+    "InferenceRuntimeSettings",
+    "WindowModelAdapter",
+    "build_track_ids",
+    "expand_batched_inference_results",
+    "load_model_from_checkpoint",
+    "load_runtime_settings",
+    "resolve_inference_device",
+]

--- a/src/inference/service.py
+++ b/src/inference/service.py
@@ -1,0 +1,114 @@
+"""Reusable service entrypoint for offline MP4 inference."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+
+from src.inference.action_event import ActionEvent
+from src.inference.engine import InferenceEngine, InferenceResult
+from src.inference.json_writer import ActionEventWriter
+from src.inference.mp4_cli import (
+    InferenceRuntimeSettings,
+    WindowModelAdapter,
+    _expand_batched_inference_results,
+    build_track_ids,
+    load_model_from_checkpoint,
+    load_runtime_settings,
+    resolve_inference_device,
+)
+from src.inference.offline_runtime import run_video
+from src.inference.tensorize import FrameTensorizer
+
+
+@dataclass(frozen=True)
+class InferenceServiceRequest:
+    """Input contract for programmatic offline MP4 inference."""
+
+    video_path: Path
+    checkpoint_path: Path
+    config_path: Path
+    device: str | None = None
+
+
+@dataclass(frozen=True)
+class InferenceServiceResult:
+    """Result object returned by the offline inference service."""
+
+    frame_count: int
+    inference_count: int
+    inference_results: tuple[InferenceResult, ...]
+    action_events: tuple[ActionEvent, ...]
+    runtime_settings: InferenceRuntimeSettings
+    resolved_device: torch.device
+
+    @property
+    def event_count(self) -> int:
+        """Return number of generated action events."""
+        return len(self.action_events)
+
+
+def run_offline_mp4_inference(request: InferenceServiceRequest) -> InferenceServiceResult:
+    """Run offline MP4 inference and return typed in-memory results."""
+    if not isinstance(request, InferenceServiceRequest):
+        raise TypeError("request must be an InferenceServiceRequest instance")
+
+    _validate_request(request)
+
+    settings = load_runtime_settings(request.config_path)
+    device = resolve_inference_device(
+        cli_device=request.device,
+        config_device=settings.device,
+    )
+    model = load_model_from_checkpoint(request.checkpoint_path, device)
+
+    tensorizer = FrameTensorizer(target_resolution=settings.target_resolution)
+    model_adapter = WindowModelAdapter(
+        model=model,
+        tensorizer=tensorizer,
+        device=device,
+    )
+    engine = InferenceEngine(
+        window_size=settings.window_size,
+        stride=settings.stride,
+        model=model_adapter,
+    )
+
+    frame_count, inference_count, inference_results, _ = run_video(
+        str(request.video_path),
+        engine=engine,
+        emit_runtime_summary=False,
+    )
+    expanded_results = _expand_batched_inference_results(inference_results)
+    track_ids = build_track_ids(expanded_results, settings.default_track_id)
+
+    writer = ActionEventWriter(class_labels=settings.class_labels)
+    writer.add_results(expanded_results, track_ids=track_ids)
+
+    return InferenceServiceResult(
+        frame_count=frame_count,
+        inference_count=inference_count,
+        inference_results=tuple(expanded_results),
+        action_events=tuple(writer.get_log().events),
+        runtime_settings=settings,
+        resolved_device=device,
+    )
+
+
+def _validate_request(request: InferenceServiceRequest) -> None:
+    """Validate request shape and path requirements."""
+    if not isinstance(request.video_path, Path):
+        raise TypeError("request.video_path must be a pathlib.Path instance")
+    if not isinstance(request.checkpoint_path, Path):
+        raise TypeError("request.checkpoint_path must be a pathlib.Path instance")
+    if not isinstance(request.config_path, Path):
+        raise TypeError("request.config_path must be a pathlib.Path instance")
+    if request.device is not None and not isinstance(request.device, str):
+        raise TypeError("request.device must be a string or None")
+
+    if not request.video_path.exists():
+        raise FileNotFoundError(f"Video file not found: {request.video_path}")
+    if not request.video_path.is_file():
+        raise ValueError(f"Video path must point to a file: {request.video_path}")
+    if request.video_path.suffix.lower() != ".mp4":
+        raise ValueError("video_path must point to an .mp4 file")

--- a/src/inference/service.py
+++ b/src/inference/service.py
@@ -8,16 +8,16 @@ import torch
 from src.inference.action_event import ActionEvent
 from src.inference.engine import InferenceEngine, InferenceResult
 from src.inference.json_writer import ActionEventWriter
-from src.inference.mp4_cli import (
+from src.inference.offline_runtime import run_video
+from src.inference.runtime import (
     InferenceRuntimeSettings,
     WindowModelAdapter,
-    _expand_batched_inference_results,
     build_track_ids,
+    expand_batched_inference_results,
     load_model_from_checkpoint,
     load_runtime_settings,
     resolve_inference_device,
 )
-from src.inference.offline_runtime import run_video
 from src.inference.tensorize import FrameTensorizer
 
 
@@ -79,7 +79,7 @@ def run_offline_mp4_inference(request: InferenceServiceRequest) -> InferenceServ
         engine=engine,
         emit_runtime_summary=False,
     )
-    expanded_results = _expand_batched_inference_results(inference_results)
+    expanded_results = expand_batched_inference_results(inference_results)
     track_ids = build_track_ids(expanded_results, settings.default_track_id)
 
     writer = ActionEventWriter(class_labels=settings.class_labels)

--- a/tests/inference/test_mp4_cli.py
+++ b/tests/inference/test_mp4_cli.py
@@ -11,14 +11,16 @@ from src.inference.action_event import ActionEvent
 from src.inference.engine import InferenceResult
 from src.inference.mp4_cli import (
     InferenceCliRequest,
+    run_mp4_to_json_action_inference,
+)
+from src.inference.runtime import (
     InferenceRuntimeSettings,
     WindowModelAdapter,
-    _expand_batched_inference_results,
     build_track_ids,
+    expand_batched_inference_results,
     load_model_from_checkpoint,
     load_runtime_settings,
     resolve_inference_device,
-    run_mp4_to_json_action_inference,
 )
 from src.inference.service import InferenceServiceResult
 from src.inference.tensorize import FrameTensorizer
@@ -116,7 +118,7 @@ def test_run_mp4_to_json_action_inference_uses_service_layer(monkeypatch, tmp_pa
         )
 
     monkeypatch.setattr(
-        "src.inference.service.run_offline_mp4_inference",
+        "src.inference.mp4_cli.run_offline_mp4_inference",
         _fake_service_runner,
     )
 
@@ -273,7 +275,7 @@ def test_expand_batched_inference_results_splits_batch_prediction():
         prediction=torch.tensor([[0.1, 0.9], [0.8, 0.2]], dtype=torch.float32),
     )
 
-    expanded = _expand_batched_inference_results([result])
+    expanded = expand_batched_inference_results([result])
 
     assert len(expanded) == 2
     assert torch.allclose(expanded[0].prediction, torch.tensor([0.1, 0.9]))

--- a/tests/inference/test_mp4_cli.py
+++ b/tests/inference/test_mp4_cli.py
@@ -7,9 +7,11 @@ import pytest
 import torch
 import yaml
 
+from src.inference.action_event import ActionEvent
 from src.inference.engine import InferenceResult
 from src.inference.mp4_cli import (
     InferenceCliRequest,
+    InferenceRuntimeSettings,
     WindowModelAdapter,
     _expand_batched_inference_results,
     build_track_ids,
@@ -18,6 +20,7 @@ from src.inference.mp4_cli import (
     resolve_inference_device,
     run_mp4_to_json_action_inference,
 )
+from src.inference.service import InferenceServiceResult
 from src.inference.tensorize import FrameTensorizer
 from src.models.dummy import DummyBehaviorModel
 
@@ -69,6 +72,71 @@ def test_run_mp4_to_json_action_inference_writes_output(dummy_video, tmp_path):
     assert payload["event_count"] > 0
     assert len(payload["events"]) == payload["event_count"]
     assert "confidence" in payload["events"][0]
+    assert payload["events"][0]["track_id"] == 1
+
+
+def test_run_mp4_to_json_action_inference_uses_service_layer(monkeypatch, tmp_path):
+    input_path = tmp_path / "sample.mp4"
+    checkpoint_path = tmp_path / "dummy_checkpoint.pth"
+    config_path = tmp_path / "inference.yml"
+    output_path = tmp_path / "actions.json"
+
+    input_path.write_bytes(b"")
+    _write_dummy_checkpoint(checkpoint_path)
+    config_path.write_text("pipeline: {}", encoding="utf-8")
+
+    captured = {}
+
+    def _fake_service_runner(request):
+        captured["request"] = request
+        return InferenceServiceResult(
+            frame_count=1,
+            inference_count=1,
+            inference_results=tuple(),
+            action_events=(
+                ActionEvent(
+                    start_frame_index=0,
+                    end_frame_index=0,
+                    start_timestamp=0.0,
+                    end_timestamp=0.0,
+                    label="class_0",
+                    confidence=0.9,
+                    track_id=1,
+                ),
+            ),
+            runtime_settings=InferenceRuntimeSettings(
+                target_resolution=(64, 64),
+                window_size=4,
+                stride=1,
+                class_labels=[],
+                default_track_id=1,
+                device=None,
+            ),
+            resolved_device=torch.device("cpu"),
+        )
+
+    monkeypatch.setattr(
+        "src.inference.service.run_offline_mp4_inference",
+        _fake_service_runner,
+    )
+
+    request = InferenceCliRequest(
+        input_path=input_path,
+        checkpoint_path=checkpoint_path,
+        config_path=config_path,
+        output_path=output_path,
+        device="cpu",
+    )
+    exit_code = run_mp4_to_json_action_inference(request)
+
+    assert exit_code == 0
+    assert captured["request"].video_path == input_path
+    assert captured["request"].checkpoint_path == checkpoint_path
+    assert captured["request"].config_path == config_path
+    assert captured["request"].device == "cpu"
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["event_count"] == 1
     assert payload["events"][0]["track_id"] == 1
 
 

--- a/tests/inference/test_service.py
+++ b/tests/inference/test_service.py
@@ -1,0 +1,74 @@
+import pytest
+import torch
+import yaml
+
+from src.inference.service import (
+    InferenceServiceRequest,
+    run_offline_mp4_inference,
+)
+from src.models.dummy import DummyBehaviorModel
+
+
+def _write_dummy_checkpoint(checkpoint_path):
+    torch.manual_seed(1234)
+    model = DummyBehaviorModel(num_classes=2)
+    checkpoint = {
+        "model_name": "dummy",
+        "model_state_dict": model.state_dict(),
+    }
+    torch.save(checkpoint, str(checkpoint_path))
+
+
+def test_run_offline_mp4_inference_returns_typed_result(dummy_video, tmp_path):
+    checkpoint_path = tmp_path / "dummy_checkpoint.pth"
+    config_path = tmp_path / "inference.yml"
+
+    _write_dummy_checkpoint(checkpoint_path)
+
+    config = {
+        "pipeline": {
+            "target_resolution": [64, 64],
+            "temporal_window": 4,
+        },
+        "inference": {
+            "stride": 2,
+            "class_labels": ["idle", "moving"],
+        },
+        "tracking": {
+            "default_track_id": 1,
+        },
+    }
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    request = InferenceServiceRequest(
+        video_path=dummy_video,
+        checkpoint_path=checkpoint_path,
+        config_path=config_path,
+    )
+
+    result = run_offline_mp4_inference(request)
+
+    assert result.frame_count == 40
+    assert result.inference_count > 0
+    assert len(result.inference_results) > 0
+    assert result.event_count > 0
+    assert len(result.action_events) == result.event_count
+    assert result.action_events[0].track_id == 1
+
+
+def test_run_offline_mp4_inference_rejects_non_mp4_video_path(tmp_path):
+    video_path = tmp_path / "sample.avi"
+    checkpoint_path = tmp_path / "dummy_checkpoint.pth"
+    config_path = tmp_path / "inference.yml"
+
+    video_path.write_bytes(b"not-an-mp4")
+    _write_dummy_checkpoint(checkpoint_path)
+    config_path.write_text("pipeline: {}", encoding="utf-8")
+
+    request = InferenceServiceRequest(
+        video_path=video_path,
+        checkpoint_path=checkpoint_path,
+        config_path=config_path,
+    )
+    with pytest.raises(ValueError, match=r"\.mp4"):
+        run_offline_mp4_inference(request)


### PR DESCRIPTION

This pull request introduces a reusable service entrypoint for offline MP4 inference, enabling programmatic integrations and simplifying the CLI wrapper logic. The main changes include the addition of a new service API, refactoring the CLI to use this service layer, and improved test coverage for the new service interface.

**New service API for offline inference:**

- Added `src/inference/service.py`, which provides a reusable, typed service entrypoint for running offline MP4 inference via the new `InferenceServiceRequest` and `InferenceServiceResult` classes, and the `run_offline_mp4_inference` function. This enables programmatic access to inference results and runtime details.
- Updated `src/inference/__init__.py` to export the new service API components for external use.

**Refactoring and CLI integration:**

- Refactored `run_mp4_to_json_action_inference` in `src/inference/mp4_cli.py` to delegate all runtime execution to the new service entrypoint, handling only output-file serialization and logging in the CLI layer.
- Cleaned up unused imports and code in `src/inference/mp4_cli.py` as a result of the refactor.

**Documentation and tests:**

- Documented the new service API usage in `docs/inference.md`, including an example for programmatic integration and a summary of returned results.
- Added comprehensive tests for the service entrypoint in `tests/inference/test_service.py`, including contract validation and error handling.
- Added a test to ensure the CLI layer correctly delegates to the service layer in `tests/inference/test_mp4_cli.py`.

**Minor improvements:**

- Added an optional `emit_runtime_summary` flag to `run_video` in `src/inference/offline_runtime.py` to suppress CLI output when called from the service layer. [[1]](diffhunk://#diff-47c40756331221e7df37098a8e2ff3b036464b7416248b915ab976b9629e2055L91-R92) [[2]](diffhunk://#diff-47c40756331221e7df37098a8e2ff3b036464b7416248b915ab976b9629e2055R101) [[3]](diffhunk://#diff-47c40756331221e7df37098a8e2ff3b036464b7416248b915ab976b9629e2055R147)

These changes make the offline inference pipeline easier to integrate, extend, and test, while keeping the CLI interface simple and focused on file I/O.

Closes #71 