### PR TITLE
feature: add file and RTSP source adapters for inference input

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -51,9 +51,11 @@ from src.inference.service import InferenceServiceRequest, run_offline_mp4_infer
 
 result = run_offline_mp4_inference(
     InferenceServiceRequest(
-        video_path=Path("data/raw/walking/sample.mp4"),
         checkpoint_path=Path("data/logs/checkpoints/baseline_epoch_10.pth"),
         config_path=Path("configs/data_pipeline.yml"),
+        video_path=Path("data/raw/walking/sample.mp4"),  # file source
+        # source_type="rtsp",
+        # source_uri="rtsp://user:password@camera-host:554/stream",
         device="auto",
     )
 )
@@ -75,6 +77,13 @@ Shared runtime primitives are implemented in `src/inference/runtime.py` and reus
 by both the service and CLI layers (`load_runtime_settings`, device resolution,
 checkpoint loading, `WindowModelAdapter`, track-id building, and
 `expand_batched_inference_results`).
+
+Input-source adapters are implemented in `src/inference/source_adapters.py`:
+- `FileSourceAdapter` for local file paths
+- `RtspSourceAdapter` for `rtsp://` and `rtsps://` streams
+
+The reusable service selects adapters via `InferenceServiceRequest.source_type`
+(`file` by default) and `video_path`/`source_uri`.
 
 ### Offline runtime details
 

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -49,21 +49,31 @@ from pathlib import Path
 
 from src.inference.service import InferenceServiceRequest, run_inference
 
-result = run_inference(
+file_result = run_inference(
     InferenceServiceRequest(
         checkpoint_path=Path("data/logs/checkpoints/baseline_epoch_10.pth"),
         config_path=Path("configs/data_pipeline.yml"),
         video_path=Path("data/raw/walking/sample.mp4"),  # file source
-        # source_type="rtsp",
-        # source_uri="rtsp://user:password@camera-host:554/stream",
         device="auto",
     )
 )
 
-print(result.frame_count, result.inference_count, result.event_count)
+rtsp_result = run_inference(
+    InferenceServiceRequest(
+        checkpoint_path=Path("data/logs/checkpoints/baseline_epoch_10.pth"),
+        config_path=Path("configs/data_pipeline.yml"),
+        video_path=None,
+        source_type="rtsp",
+        source_uri="rtsp://user:password@camera-host:554/stream",
+        device="auto",
+    )
+)
+
+print(file_result.event_count, rtsp_result.event_count)
 ```
 
 For MP4-only offline callers, `run_offline_mp4_inference` is kept as a compatibility wrapper.
+Use this wrapper only for legacy MP4/offline integrations (including the MP4 CLI wrapper).
 It validates `source_type="file"`, requires `video_path`, and requires an `.mp4` suffix.
 
 The service returns a typed in-memory result with:

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -47,9 +47,9 @@ service API instead of the CLI wrapper:
 ```python
 from pathlib import Path
 
-from src.inference.service import InferenceServiceRequest, run_offline_mp4_inference
+from src.inference.service import InferenceServiceRequest, run_inference
 
-result = run_offline_mp4_inference(
+result = run_inference(
     InferenceServiceRequest(
         checkpoint_path=Path("data/logs/checkpoints/baseline_epoch_10.pth"),
         config_path=Path("configs/data_pipeline.yml"),
@@ -62,6 +62,9 @@ result = run_offline_mp4_inference(
 
 print(result.frame_count, result.inference_count, result.event_count)
 ```
+
+For MP4-only offline callers, `run_offline_mp4_inference` is kept as a compatibility wrapper.
+It validates `source_type="file"`, requires `video_path`, and requires an `.mp4` suffix.
 
 The service returns a typed in-memory result with:
 - processed frame count

--- a/src/inference/__init__.py
+++ b/src/inference/__init__.py
@@ -6,7 +6,14 @@ from src.inference.json_writer import ActionEventWriter
 from src.inference.service import (
     InferenceServiceRequest,
     InferenceServiceResult,
+    run_inference,
     run_offline_mp4_inference,
+)
+from src.inference.source_adapters import (
+    FileSourceAdapter,
+    InferenceSourceAdapter,
+    RtspSourceAdapter,
+    build_source_adapter,
 )
 
 __all__ = [
@@ -17,5 +24,10 @@ __all__ = [
     "InferenceResult",
     "InferenceServiceRequest",
     "InferenceServiceResult",
+    "InferenceSourceAdapter",
+    "FileSourceAdapter",
+    "RtspSourceAdapter",
+    "build_source_adapter",
+    "run_inference",
     "run_offline_mp4_inference",
 ]

--- a/src/inference/offline_runtime.py
+++ b/src/inference/offline_runtime.py
@@ -1,39 +1,38 @@
-"""Offline producer-consumer runtime for MP4 inference."""
+"""Offline producer-consumer runtime for adapter-based inference inputs."""
 from pathlib import Path
 from queue import Queue
 from threading import Thread
 from typing import Any, Optional
 
-import cv2
-
 from src.inference.engine import InferenceEngine
 from src.inference.json_writer import ActionEventWriter
+from src.inference.source_adapters import FileSourceAdapter, InferenceSourceAdapter
 from src.inference.tracker import BaseTracker, SingleTrackTracker
 
 EOF_SENTINEL = object()
 
 
-def produce_frames(video_path: str, frame_queue: Queue) -> None:
-    """Reads frames from a video file in source order and pushes them to a queue.
+def produce_frames_from_source(
+    source_adapter: InferenceSourceAdapter,
+    frame_queue: Queue,
+) -> None:
+    """Reads frames from a source adapter in source order and pushes them to a queue.
 
     Args:
-        video_path (str): Path to the input video file.
+        source_adapter (InferenceSourceAdapter): Source adapter to open and read.
         frame_queue (Queue): Queue used to pass frames to the consumer.
 
     Raises:
-        FileNotFoundError: If the video file does not exist.
-        RuntimeError: If the video cannot be opened.
+        RuntimeError: If the source cannot be opened.
     """
     try:
-        path = Path(video_path)
-
-        if not path.exists():
-            raise FileNotFoundError(f"Video file not found: {path}")
-
-        cap = cv2.VideoCapture(str(path))
+        cap = source_adapter.open_capture()
 
         if not cap.isOpened():
-            raise RuntimeError(f"Could not open video file: {path}")
+            raise RuntimeError(
+                "Could not open "
+                f"{source_adapter.source_type} source: {source_adapter.source_ref}",
+            )
 
         try:
             while True:
@@ -49,10 +48,23 @@ def produce_frames(video_path: str, frame_queue: Queue) -> None:
         frame_queue.put(EOF_SENTINEL)
 
 
-def produce_frames_safe(video_path: str, frame_queue: Queue, stats: dict) -> None:
+def produce_frames(video_path: str, frame_queue: Queue) -> None:
+    """Backward-compatible file-source producer."""
+    if not isinstance(video_path, str):
+        raise TypeError("video_path must be a string")
+
+    source_adapter = FileSourceAdapter(video_path=Path(video_path))
+    produce_frames_from_source(source_adapter, frame_queue)
+
+
+def produce_frames_safe(
+    source_adapter: InferenceSourceAdapter,
+    frame_queue: Queue,
+    stats: dict,
+) -> None:
     """Runs the frame producer and stores any raised exception in stats."""
     try:
-        produce_frames(video_path, frame_queue)
+        produce_frames_from_source(source_adapter, frame_queue)
     except Exception as exc:
         stats["producer_error"] = exc
 
@@ -85,16 +97,16 @@ def consume_frame_queue(frame_queue: Queue, engine: InferenceEngine, stats: dict
     stats["inference_results"] = inference_results
 
 
-def run_video(
-    video_path: str,
+def run_source(
+    source_adapter: InferenceSourceAdapter,
     engine: Optional[InferenceEngine] = None,
     tracker: Optional[BaseTracker] = None,
     emit_runtime_summary: bool = True,
 ) -> tuple[int, int, list[Any], list[Any]]:
-    """Runs offline inference on a single video file.
+    """Runs offline inference on a generic source adapter.
 
     Args:
-        video_path (str): Path to the input video file.
+        source_adapter: Adapter that provides inference input frames.
         engine: Optional inference engine instance. If None, a default
             InferenceEngine is created.
         tracker: Optional tracker used to assign track IDs to inference results.
@@ -105,6 +117,9 @@ def run_video(
         number of inference windows, collected inference results, and output
         action events.
     """
+    if not isinstance(source_adapter, InferenceSourceAdapter):
+        raise TypeError("source_adapter must be an InferenceSourceAdapter instance")
+
     runtime_engine = engine  # engine initialization moved to mp4_cli.py
     if runtime_engine is None:
         runtime_engine = InferenceEngine()
@@ -120,7 +135,7 @@ def run_video(
     }
 
     producer = Thread(target=produce_frames_safe,
-                      args=(video_path, frame_queue, stats))
+                      args=(source_adapter, frame_queue, stats))
     consumer = Thread(target=consume_frame_queue,
                       args=(frame_queue, runtime_engine, stats))
 
@@ -150,3 +165,22 @@ def run_video(
         print(f"Generated {len(action_events)} action events")
 
     return frame_count, inference_count, inference_results, action_events
+
+
+def run_video(
+    video_path: str,
+    engine: Optional[InferenceEngine] = None,
+    tracker: Optional[BaseTracker] = None,
+    emit_runtime_summary: bool = True,
+) -> tuple[int, int, list[Any], list[Any]]:
+    """Runs offline inference on a single local video file."""
+    if not isinstance(video_path, str):
+        raise TypeError("video_path must be a string")
+
+    source_adapter = FileSourceAdapter(video_path=Path(video_path))
+    return run_source(
+        source_adapter=source_adapter,
+        engine=engine,
+        tracker=tracker,
+        emit_runtime_summary=emit_runtime_summary,
+    )

--- a/src/inference/service.py
+++ b/src/inference/service.py
@@ -30,9 +30,9 @@ from src.inference.tensorize import FrameTensorizer
 class InferenceServiceRequest:
     """Input contract for programmatic inference over file/RTSP sources."""
 
-    video_path: Path | None
     checkpoint_path: Path
     config_path: Path
+    video_path: Path | None = None
     source_uri: str | None = None
     source_type: str = "file"
     device: str | None = None

--- a/src/inference/service.py
+++ b/src/inference/service.py
@@ -104,8 +104,33 @@ def run_inference(request: InferenceServiceRequest) -> InferenceServiceResult:
 
 
 def run_offline_mp4_inference(request: InferenceServiceRequest) -> InferenceServiceResult:
-    """Backward-compatible wrapper around the generic inference service."""
+    """Run offline inference for local MP4 files only."""
+    if not isinstance(request, InferenceServiceRequest):
+        raise TypeError("request must be an InferenceServiceRequest instance")
+    _validate_offline_mp4_request(request)
     return run_inference(request)
+
+
+def _validate_offline_mp4_request(request: InferenceServiceRequest) -> None:
+    """Validate MP4-only constraints for the backward-compatible wrapper."""
+    source_type = normalize_source_type(request.source_type)
+    if source_type != "file":
+        raise ValueError(
+            "run_offline_mp4_inference supports only file sources (source_type='file')"
+        )
+    if request.video_path is None:
+        raise ValueError(
+            "run_offline_mp4_inference requires request.video_path pointing to an .mp4 file"
+        )
+    if request.source_uri is not None:
+        raise ValueError(
+            "run_offline_mp4_inference does not accept request.source_uri; "
+            "provide request.video_path"
+        )
+    if request.video_path.suffix.lower() != ".mp4":
+        raise ValueError(
+            "run_offline_mp4_inference requires request.video_path with .mp4 extension"
+        )
 
 
 def _validate_request(request: InferenceServiceRequest) -> None:

--- a/src/inference/service.py
+++ b/src/inference/service.py
@@ -1,4 +1,4 @@
-"""Reusable service entrypoint for offline MP4 inference."""
+"""Reusable service entrypoint for adapter-based inference sources."""
 
 from dataclasses import dataclass
 from pathlib import Path
@@ -8,7 +8,7 @@ import torch
 from src.inference.action_event import ActionEvent
 from src.inference.engine import InferenceEngine, InferenceResult
 from src.inference.json_writer import ActionEventWriter
-from src.inference.offline_runtime import run_video
+from src.inference.offline_runtime import run_source
 from src.inference.runtime import (
     InferenceRuntimeSettings,
     WindowModelAdapter,
@@ -18,22 +18,29 @@ from src.inference.runtime import (
     load_runtime_settings,
     resolve_inference_device,
 )
+from src.inference.source_adapters import (
+    InferenceSourceAdapter,
+    build_source_adapter,
+    normalize_source_type,
+)
 from src.inference.tensorize import FrameTensorizer
 
 
 @dataclass(frozen=True)
 class InferenceServiceRequest:
-    """Input contract for programmatic offline MP4 inference."""
+    """Input contract for programmatic inference over file/RTSP sources."""
 
-    video_path: Path
+    video_path: Path | None
     checkpoint_path: Path
     config_path: Path
+    source_uri: str | None = None
+    source_type: str = "file"
     device: str | None = None
 
 
 @dataclass(frozen=True)
 class InferenceServiceResult:
-    """Result object returned by the offline inference service."""
+    """Result object returned by the reusable inference service."""
 
     frame_count: int
     inference_count: int
@@ -48,12 +55,13 @@ class InferenceServiceResult:
         return len(self.action_events)
 
 
-def run_offline_mp4_inference(request: InferenceServiceRequest) -> InferenceServiceResult:
-    """Run offline MP4 inference and return typed in-memory results."""
+def run_inference(request: InferenceServiceRequest) -> InferenceServiceResult:
+    """Run inference and return typed in-memory results."""
     if not isinstance(request, InferenceServiceRequest):
         raise TypeError("request must be an InferenceServiceRequest instance")
 
     _validate_request(request)
+    source_adapter = _build_request_source_adapter(request)
 
     settings = load_runtime_settings(request.config_path)
     device = resolve_inference_device(
@@ -74,8 +82,8 @@ def run_offline_mp4_inference(request: InferenceServiceRequest) -> InferenceServ
         model=model_adapter,
     )
 
-    frame_count, inference_count, inference_results, _ = run_video(
-        str(request.video_path),
+    frame_count, inference_count, inference_results, _ = run_source(
+        source_adapter=source_adapter,
         engine=engine,
         emit_runtime_summary=False,
     )
@@ -95,20 +103,45 @@ def run_offline_mp4_inference(request: InferenceServiceRequest) -> InferenceServ
     )
 
 
+def run_offline_mp4_inference(request: InferenceServiceRequest) -> InferenceServiceResult:
+    """Backward-compatible wrapper around the generic inference service."""
+    return run_inference(request)
+
+
 def _validate_request(request: InferenceServiceRequest) -> None:
     """Validate request shape and path requirements."""
-    if not isinstance(request.video_path, Path):
-        raise TypeError("request.video_path must be a pathlib.Path instance")
     if not isinstance(request.checkpoint_path, Path):
         raise TypeError("request.checkpoint_path must be a pathlib.Path instance")
     if not isinstance(request.config_path, Path):
         raise TypeError("request.config_path must be a pathlib.Path instance")
+    if request.video_path is not None and not isinstance(request.video_path, Path):
+        raise TypeError("request.video_path must be a pathlib.Path instance or None")
+    if request.source_uri is not None and not isinstance(request.source_uri, str):
+        raise TypeError("request.source_uri must be a string or None")
+    normalize_source_type(request.source_type)
     if request.device is not None and not isinstance(request.device, str):
         raise TypeError("request.device must be a string or None")
 
-    if not request.video_path.exists():
-        raise FileNotFoundError(f"Video file not found: {request.video_path}")
-    if not request.video_path.is_file():
-        raise ValueError(f"Video path must point to a file: {request.video_path}")
-    if request.video_path.suffix.lower() != ".mp4":
-        raise ValueError("video_path must point to an .mp4 file")
+    if request.video_path is not None and request.source_uri is not None:
+        raise ValueError("Provide either request.video_path or request.source_uri, not both")
+
+    source_type = normalize_source_type(request.source_type)
+    if source_type == "file" and request.video_path is None and request.source_uri is None:
+        raise ValueError("File source requires request.video_path or request.source_uri")
+    if source_type == "rtsp" and request.source_uri is None:
+        raise ValueError("RTSP source requires request.source_uri")
+
+
+def _build_request_source_adapter(request: InferenceServiceRequest) -> InferenceSourceAdapter:
+    """Build source adapter from request fields."""
+    source_type = normalize_source_type(request.source_type)
+    if source_type == "file":
+        if request.video_path is not None:
+            return build_source_adapter(source_type="file", source_ref=request.video_path)
+        if request.source_uri is None:
+            raise ValueError("File source requires request.video_path or request.source_uri")
+        return build_source_adapter(source_type="file", source_ref=Path(request.source_uri))
+
+    if request.source_uri is None:
+        raise ValueError("RTSP source requires request.source_uri")
+    return build_source_adapter(source_type="rtsp", source_ref=request.source_uri)

--- a/src/inference/source_adapters.py
+++ b/src/inference/source_adapters.py
@@ -1,0 +1,131 @@
+"""Source adapters for inference frame ingestion."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import cv2
+
+SourceType = Literal["file", "rtsp"]
+
+
+class InferenceSourceAdapter(ABC):
+    """Common adapter contract for inference input sources."""
+
+    @property
+    @abstractmethod
+    def source_type(self) -> SourceType:
+        """Return normalized source type identifier."""
+
+    @property
+    @abstractmethod
+    def source_ref(self) -> str:
+        """Return source path/URI in string form."""
+
+    @abstractmethod
+    def open_capture(self) -> cv2.VideoCapture:
+        """Create and return a cv2 capture for this source."""
+
+
+@dataclass(frozen=True)
+class FileSourceAdapter(InferenceSourceAdapter):
+    """Adapter for local video-file inference sources."""
+
+    video_path: Path
+
+    def __post_init__(self) -> None:
+        """Validate file-based source metadata."""
+        if not isinstance(self.video_path, Path):
+            raise TypeError("video_path must be a pathlib.Path instance")
+        if not self.video_path.exists():
+            raise FileNotFoundError(f"Video file not found: {self.video_path}")
+        if not self.video_path.is_file():
+            raise ValueError(f"Video path must point to a file: {self.video_path}")
+
+    @property
+    def source_type(self) -> SourceType:
+        """Return source type identifier."""
+        return "file"
+
+    @property
+    def source_ref(self) -> str:
+        """Return file path as string reference."""
+        return str(self.video_path)
+
+    def open_capture(self) -> cv2.VideoCapture:
+        """Open cv2 capture for a local file source."""
+        return cv2.VideoCapture(self.source_ref)
+
+
+@dataclass(frozen=True)
+class RtspSourceAdapter(InferenceSourceAdapter):
+    """Adapter for RTSP inference sources."""
+
+    rtsp_uri: str
+
+    def __post_init__(self) -> None:
+        """Validate RTSP URI."""
+        if not isinstance(self.rtsp_uri, str):
+            raise TypeError("rtsp_uri must be a string")
+        normalized = self.rtsp_uri.strip()
+        if not normalized:
+            raise ValueError("rtsp_uri must not be empty")
+        if not normalized.lower().startswith(("rtsp://", "rtsps://")):
+            raise ValueError("rtsp_uri must start with rtsp:// or rtsps://")
+        object.__setattr__(self, "rtsp_uri", normalized)
+
+    @property
+    def source_type(self) -> SourceType:
+        """Return source type identifier."""
+        return "rtsp"
+
+    @property
+    def source_ref(self) -> str:
+        """Return RTSP URI."""
+        return self.rtsp_uri
+
+    def open_capture(self) -> cv2.VideoCapture:
+        """Open cv2 capture for an RTSP source."""
+        return cv2.VideoCapture(self.source_ref)
+
+
+def normalize_source_type(source_type: str) -> SourceType:
+    """Normalize and validate a source type value."""
+    if not isinstance(source_type, str):
+        raise TypeError("source_type must be a string")
+    normalized = source_type.strip().lower()
+    if normalized == "file":
+        return "file"
+    if normalized == "rtsp":
+        return "rtsp"
+    raise ValueError("source_type must be one of: file, rtsp")
+
+
+def build_source_adapter(
+    source_type: str,
+    source_ref: Path | str,
+) -> InferenceSourceAdapter:
+    """Build a source adapter for a given source type and source reference."""
+    normalized_source_type = normalize_source_type(source_type)
+    if normalized_source_type == "file":
+        if isinstance(source_ref, Path):
+            return FileSourceAdapter(video_path=source_ref)
+        if isinstance(source_ref, str):
+            return FileSourceAdapter(video_path=Path(source_ref))
+        raise TypeError("file source_ref must be a pathlib.Path or string path")
+
+    if not isinstance(source_ref, str):
+        raise TypeError("rtsp source_ref must be a string URI")
+    return RtspSourceAdapter(rtsp_uri=source_ref)
+
+
+__all__ = [
+    "InferenceSourceAdapter",
+    "FileSourceAdapter",
+    "RtspSourceAdapter",
+    "build_source_adapter",
+    "normalize_source_type",
+]

--- a/tests/inference/test_offline_runtime.py
+++ b/tests/inference/test_offline_runtime.py
@@ -3,16 +3,19 @@ import numpy as np
 import pytest
 
 from src.inference.engine import InferenceEngine
-from src.inference.offline_runtime import run_video
+from src.inference.offline_runtime import run_source, run_video
+from src.inference.source_adapters import RtspSourceAdapter
 
 
 class DummyPredictionModel:
     def __call__(self, window):
         return {"label": "action", "confidence": 0.9}
 
+
 def test_run_video_raises_on_invalid_path_without_hanging():
     with pytest.raises(FileNotFoundError):
         run_video("path/that/does/not/exist.mp4")
+
 
 def test_run_video_processes_sample_mp4_and_exposes_track_id(tmp_path):
     video_path = tmp_path / "sample.mp4"
@@ -51,4 +54,51 @@ def test_run_video_processes_sample_mp4_and_exposes_track_id(tmp_path):
     assert first_result.end_timestamp is not None
     assert first_result.end_timestamp >= first_result.start_timestamp
 
+    assert all(event.track_id == 1 for event in action_events)
+
+
+def test_run_source_processes_rtsp_adapter_frames(monkeypatch):
+    frames = [np.full((64, 64, 3), fill_value=i, dtype=np.uint8) for i in range(10)]
+    captured = {}
+
+    class _FakeCapture:
+        def __init__(self, source_ref):
+            self._source_ref = source_ref
+            self._remaining_frames = list(frames)
+            self.released = False
+
+        def isOpened(self):
+            return True
+
+        def read(self):
+            if not self._remaining_frames:
+                return False, None
+            return True, self._remaining_frames.pop(0)
+
+        def release(self):
+            self.released = True
+
+    def _fake_video_capture(source_ref):
+        capture = _FakeCapture(source_ref)
+        captured["source_ref"] = source_ref
+        captured["capture"] = capture
+        return capture
+
+    monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake_video_capture)
+
+    adapter = RtspSourceAdapter(rtsp_uri="rtsp://localhost:8554/live")
+    engine = InferenceEngine(window_size=4, stride=2, model=DummyPredictionModel())
+
+    processed_frames, inference_windows, inference_results, action_events = run_source(
+        source_adapter=adapter,
+        engine=engine,
+        emit_runtime_summary=False,
+    )
+
+    assert captured["source_ref"] == "rtsp://localhost:8554/live"
+    assert captured["capture"].released is True
+    assert processed_frames == len(frames)
+    assert inference_windows > 0
+    assert len(inference_results) == inference_windows
+    assert len(action_events) == inference_windows
     assert all(event.track_id == 1 for event in action_events)

--- a/tests/inference/test_service.py
+++ b/tests/inference/test_service.py
@@ -100,3 +100,39 @@ def test_run_inference_rejects_rtsp_request_without_uri(tmp_path):
 
     with pytest.raises(ValueError, match="request.source_uri"):
         run_inference(request)
+
+
+def test_run_offline_mp4_inference_rejects_rtsp_request(tmp_path):
+    request = InferenceServiceRequest(
+        video_path=None,
+        checkpoint_path=tmp_path / "dummy_checkpoint.pth",
+        config_path=tmp_path / "inference.yml",
+        source_type="rtsp",
+        source_uri="rtsp://camera.local/stream",
+    )
+
+    with pytest.raises(ValueError, match="supports only file sources"):
+        run_offline_mp4_inference(request)
+
+
+def test_run_offline_mp4_inference_rejects_non_mp4_input(tmp_path):
+    request = InferenceServiceRequest(
+        video_path=tmp_path / "sample.avi",
+        checkpoint_path=tmp_path / "dummy_checkpoint.pth",
+        config_path=tmp_path / "inference.yml",
+    )
+
+    with pytest.raises(ValueError, match=r"\.mp4 extension"):
+        run_offline_mp4_inference(request)
+
+
+def test_run_offline_mp4_inference_rejects_source_uri(tmp_path):
+    request = InferenceServiceRequest(
+        video_path=tmp_path / "sample.mp4",
+        checkpoint_path=tmp_path / "dummy_checkpoint.pth",
+        config_path=tmp_path / "inference.yml",
+        source_uri="sample.mp4",
+    )
+
+    with pytest.raises(ValueError, match="does not accept request.source_uri"):
+        run_offline_mp4_inference(request)

--- a/tests/inference/test_service.py
+++ b/tests/inference/test_service.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 import torch
 import yaml
@@ -22,12 +23,7 @@ def _write_dummy_checkpoint(checkpoint_path):
     torch.save(checkpoint, str(checkpoint_path))
 
 
-def test_run_offline_mp4_inference_returns_typed_result(dummy_video, tmp_path):
-    checkpoint_path = tmp_path / "dummy_checkpoint.pth"
-    config_path = tmp_path / "inference.yml"
-
-    _write_dummy_checkpoint(checkpoint_path)
-
+def _write_inference_config(config_path):
     config = {
         "pipeline": {
             "target_resolution": [64, 64],
@@ -43,6 +39,14 @@ def test_run_offline_mp4_inference_returns_typed_result(dummy_video, tmp_path):
     }
     config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
 
+
+def test_run_offline_mp4_inference_returns_typed_result(dummy_video, tmp_path):
+    checkpoint_path = tmp_path / "dummy_checkpoint.pth"
+    config_path = tmp_path / "inference.yml"
+
+    _write_dummy_checkpoint(checkpoint_path)
+    _write_inference_config(config_path)
+
     request = InferenceServiceRequest(
         video_path=dummy_video,
         checkpoint_path=checkpoint_path,
@@ -57,6 +61,58 @@ def test_run_offline_mp4_inference_returns_typed_result(dummy_video, tmp_path):
     assert result.event_count > 0
     assert len(result.action_events) == result.event_count
     assert result.action_events[0].track_id == 1
+
+
+def test_run_inference_processes_rtsp_frames_with_runtime(monkeypatch, tmp_path):
+    checkpoint_path = tmp_path / "dummy_checkpoint.pth"
+    config_path = tmp_path / "inference.yml"
+    _write_dummy_checkpoint(checkpoint_path)
+    _write_inference_config(config_path)
+
+    frames = [np.full((64, 64, 3), fill_value=i * 10, dtype=np.uint8) for i in range(10)]
+    capture_state = {}
+
+    class _FakeCapture:
+        def __init__(self, source_ref):
+            self._frames = list(frames)
+            self.released = False
+            self.source_ref = source_ref
+
+        def isOpened(self):
+            return True
+
+        def read(self):
+            if not self._frames:
+                return False, None
+            return True, self._frames.pop(0)
+
+        def release(self):
+            self.released = True
+
+    def _fake_video_capture(source_ref):
+        capture = _FakeCapture(source_ref)
+        capture_state["source_ref"] = source_ref
+        capture_state["capture"] = capture
+        return capture
+
+    monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake_video_capture)
+
+    request = InferenceServiceRequest(
+        video_path=None,
+        checkpoint_path=checkpoint_path,
+        config_path=config_path,
+        source_type="rtsp",
+        source_uri="rtsp://camera.local/stream",
+    )
+    result = run_inference(request)
+
+    assert capture_state["source_ref"] == "rtsp://camera.local/stream"
+    assert capture_state["capture"].released is True
+    assert result.frame_count == len(frames)
+    assert result.inference_count > 0
+    assert len(result.inference_results) > 0
+    assert result.event_count > 0
+    assert all(event.track_id == 1 for event in result.action_events)
 
 
 def test_build_request_source_adapter_accepts_non_mp4_file_path(tmp_path):

--- a/tests/inference/test_service.py
+++ b/tests/inference/test_service.py
@@ -4,8 +4,11 @@ import yaml
 
 from src.inference.service import (
     InferenceServiceRequest,
+    _build_request_source_adapter,
+    run_inference,
     run_offline_mp4_inference,
 )
+from src.inference.source_adapters import FileSourceAdapter, RtspSourceAdapter
 from src.models.dummy import DummyBehaviorModel
 
 
@@ -56,19 +59,44 @@ def test_run_offline_mp4_inference_returns_typed_result(dummy_video, tmp_path):
     assert result.action_events[0].track_id == 1
 
 
-def test_run_offline_mp4_inference_rejects_non_mp4_video_path(tmp_path):
+def test_build_request_source_adapter_accepts_non_mp4_file_path(tmp_path):
     video_path = tmp_path / "sample.avi"
-    checkpoint_path = tmp_path / "dummy_checkpoint.pth"
-    config_path = tmp_path / "inference.yml"
-
-    video_path.write_bytes(b"not-an-mp4")
-    _write_dummy_checkpoint(checkpoint_path)
-    config_path.write_text("pipeline: {}", encoding="utf-8")
+    video_path.write_bytes(b"")
 
     request = InferenceServiceRequest(
         video_path=video_path,
-        checkpoint_path=checkpoint_path,
-        config_path=config_path,
+        checkpoint_path=tmp_path / "dummy_checkpoint.pth",
+        config_path=tmp_path / "inference.yml",
     )
-    with pytest.raises(ValueError, match=r"\.mp4"):
-        run_offline_mp4_inference(request)
+
+    adapter = _build_request_source_adapter(request)
+
+    assert isinstance(adapter, FileSourceAdapter)
+    assert adapter.source_ref == str(video_path)
+
+
+def test_build_request_source_adapter_creates_rtsp_adapter(tmp_path):
+    request = InferenceServiceRequest(
+        video_path=None,
+        checkpoint_path=tmp_path / "dummy_checkpoint.pth",
+        config_path=tmp_path / "inference.yml",
+        source_type="rtsp",
+        source_uri="rtsp://camera.local/stream",
+    )
+
+    adapter = _build_request_source_adapter(request)
+
+    assert isinstance(adapter, RtspSourceAdapter)
+    assert adapter.source_ref == "rtsp://camera.local/stream"
+
+
+def test_run_inference_rejects_rtsp_request_without_uri(tmp_path):
+    request = InferenceServiceRequest(
+        video_path=None,
+        checkpoint_path=tmp_path / "dummy_checkpoint.pth",
+        config_path=tmp_path / "inference.yml",
+        source_type="rtsp",
+    )
+
+    with pytest.raises(ValueError, match="request.source_uri"):
+        run_inference(request)

--- a/tests/inference/test_source_adapters.py
+++ b/tests/inference/test_source_adapters.py
@@ -1,3 +1,5 @@
+import pytest
+
 from src.inference.source_adapters import (
     FileSourceAdapter,
     RtspSourceAdapter,
@@ -66,9 +68,5 @@ def test_rtsp_source_adapter_open_capture_uses_rtsp_uri(monkeypatch):
 
 
 def test_rtsp_source_adapter_rejects_non_rtsp_uri():
-    try:
+    with pytest.raises(ValueError, match="rtsp_uri must start with rtsp:// or rtsps://"):
         RtspSourceAdapter(rtsp_uri="http://localhost/live")
-    except ValueError as error:
-        assert "rtsp_uri must start with rtsp://" in str(error)
-    else:
-        raise AssertionError("Expected ValueError for non-RTSP URI")

--- a/tests/inference/test_source_adapters.py
+++ b/tests/inference/test_source_adapters.py
@@ -1,0 +1,74 @@
+from src.inference.source_adapters import (
+    FileSourceAdapter,
+    RtspSourceAdapter,
+    build_source_adapter,
+)
+
+
+def test_build_source_adapter_creates_file_adapter(tmp_path):
+    video_path = tmp_path / "sample.mp4"
+    video_path.write_bytes(b"")
+
+    adapter = build_source_adapter(source_type="file", source_ref=video_path)
+
+    assert isinstance(adapter, FileSourceAdapter)
+    assert adapter.source_ref == str(video_path)
+
+
+def test_build_source_adapter_creates_rtsp_adapter():
+    adapter = build_source_adapter(
+        source_type="rtsp",
+        source_ref="rtsp://localhost:8554/live",
+    )
+
+    assert isinstance(adapter, RtspSourceAdapter)
+    assert adapter.source_ref == "rtsp://localhost:8554/live"
+
+
+def test_file_source_adapter_open_capture_uses_file_path(tmp_path, monkeypatch):
+    video_path = tmp_path / "sample.mp4"
+    video_path.write_bytes(b"")
+    captured = {}
+
+    class _FakeCapture:
+        pass
+
+    def _fake_video_capture(source_ref):
+        captured["source_ref"] = source_ref
+        return _FakeCapture()
+
+    monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake_video_capture)
+
+    adapter = FileSourceAdapter(video_path=video_path)
+    capture = adapter.open_capture()
+
+    assert isinstance(capture, _FakeCapture)
+    assert captured["source_ref"] == str(video_path)
+
+
+def test_rtsp_source_adapter_open_capture_uses_rtsp_uri(monkeypatch):
+    captured = {}
+
+    class _FakeCapture:
+        pass
+
+    def _fake_video_capture(source_ref):
+        captured["source_ref"] = source_ref
+        return _FakeCapture()
+
+    monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake_video_capture)
+
+    adapter = RtspSourceAdapter(rtsp_uri="rtsps://localhost:8554/live")
+    capture = adapter.open_capture()
+
+    assert isinstance(capture, _FakeCapture)
+    assert captured["source_ref"] == "rtsps://localhost:8554/live"
+
+
+def test_rtsp_source_adapter_rejects_non_rtsp_uri():
+    try:
+        RtspSourceAdapter(rtsp_uri="http://localhost/live")
+    except ValueError as error:
+        assert "rtsp_uri must start with rtsp://" in str(error)
+    else:
+        raise AssertionError("Expected ValueError for non-RTSP URI")


### PR DESCRIPTION
This pull request refactors the inference service and offline runtime to support flexible input sources (both local files and RTSP streams) via a new adapter-based architecture. It introduces a unified interface for ingesting frames from different sources, generalizes the service API, and updates validation logic and documentation accordingly. Backward compatibility is maintained for existing file-based workflows.

**Adapter-based input source support:**

* Introduced `InferenceSourceAdapter` (with `FileSourceAdapter` and `RtspSourceAdapter` implementations) as a unified interface for ingesting frames from local files or RTSP streams. Added `build_source_adapter` and `normalize_source_type` utilities for adapter creation and type validation. (`src/inference/source_adapters.py`)
* Updated `offline_runtime` to use `InferenceSourceAdapter` for frame production and consumption, replacing file-specific logic with generic, adapter-driven processing. Added `run_source` for generic sources and kept `run_video` as a backward-compatible wrapper. (`src/inference/offline_runtime.py`) [[1]](diffhunk://#diff-47c40756331221e7df37098a8e2ff3b036464b7416248b915ab976b9629e2055L1-R35) [[2]](diffhunk://#diff-47c40756331221e7df37098a8e2ff3b036464b7416248b915ab976b9629e2055L52-R67) [[3]](diffhunk://#diff-47c40756331221e7df37098a8e2ff3b036464b7416248b915ab976b9629e2055L88-R109) [[4]](diffhunk://#diff-47c40756331221e7df37098a8e2ff3b036464b7416248b915ab976b9629e2055R168-R186)

**Service API and validation changes:**

* Refactored `InferenceServiceRequest` to support both `video_path` and `source_uri` (with `source_type`), enabling RTSP and file-based sources. Updated validation logic to enforce correct field combinations and source requirements. (`src/inference/service.py`) [[1]](diffhunk://#diff-7899a5150824ad47c3e99c26982991ce4bc98fc95dba72905cdebdae9009b6c0R21-R43) [[2]](diffhunk://#diff-7899a5150824ad47c3e99c26982991ce4bc98fc95dba72905cdebdae9009b6c0R106-R147)
* Generalized the main entrypoint to `run_inference`, which uses the adapter-based approach. The legacy `run_offline_mp4_inference` remains as a wrapper for compatibility. (`src/inference/service.py`, `src/inference/__init__.py`) [[1]](diffhunk://#diff-7899a5150824ad47c3e99c26982991ce4bc98fc95dba72905cdebdae9009b6c0L51-R64) [[2]](diffhunk://#diff-7899a5150824ad47c3e99c26982991ce4bc98fc95dba72905cdebdae9009b6c0R106-R147) [[3]](diffhunk://#diff-f4095f7855c6078e6eae8c29c789895b92b0695100ef92079cc0bcf0d243766bR9-R17) [[4]](diffhunk://#diff-f4095f7855c6078e6eae8c29c789895b92b0695100ef92079cc0bcf0d243766bR27-R31)

**Documentation and test updates:**

* Updated documentation to describe the new input-source adapter system and how to select sources via `InferenceServiceRequest`. (`docs/inference.md`)
* Added and revised tests to cover adapter creation, RTSP support, and validation of source fields. (`tests/inference/test_service.py`)

These changes enable the inference service to flexibly support new video input types with a clean, extensible architecture, while maintaining compatibility with existing file-based workflows.

Closes #72 