### PR TITLE
Add frontend-quality GitHub Actions job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,31 @@ jobs:
         env:
           PYTHONPATH: .
         run: python -m pytest -q tests
+
+  frontend-quality:
+    name: frontend-quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Lint frontend
+        working-directory: frontend
+        run: npm run lint
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -5,10 +5,12 @@
 ## CI
 
 - Trigger: `pull_request` to `main`, `workflow_dispatch`
-- Purpose: run Python tests and Ruff linting
+- Purpose: run Python tests, Ruff linting, and frontend quality checks
 - Behavior:
   - on pull requests, Ruff checks changed Python files
   - on manual runs, Ruff checks all Python files under `src` and `tests`
+  - frontend checks use Node.js 20 with npm caching from `frontend/package-lock.json`
+  - frontend checks run `npm ci`, `npm run lint`, and `npm run build` from `frontend/`
 
 ## Docker Smoke
 


### PR DESCRIPTION
## Summary
Add a frontend-quality job to .github/workflows/ci.yml that runs on ubuntu-latest with a 10-minute timeout. It sets up Node.js 20 with npm caching (using frontend/package-lock.json), runs npm ci, npm run lint, and npm run build in the frontend/ directory. Update docs/ci-workflows.md to document the new frontend checks and caching behavior.

## Linked Issue
Closes #102

## Checklist
- [x] Changes were tested locally
- [x] CI passes
- [x] README/docs updated if relevant
- [x] Scope matches the linked Issue
- [x] No direct work outside the agreed scope