### PR TITLE
74 feature handle stream interruption and graceful reconnect in runtime

### DIFF
--- a/src/inference/__init__.py
+++ b/src/inference/__init__.py
@@ -3,6 +3,11 @@
 from src.inference.action_event import ActionEvent, ActionEventLog
 from src.inference.engine import InferenceEngine, InferenceResult
 from src.inference.json_writer import ActionEventWriter
+from src.inference.offline_runtime import (
+    RuntimeFailureState,
+    SourceInterruptedError,
+    run_source_with_reconnect,
+)
 from src.inference.service import (
     InferenceServiceRequest,
     InferenceServiceResult,
@@ -26,8 +31,11 @@ __all__ = [
     "InferenceServiceResult",
     "InferenceSourceAdapter",
     "FileSourceAdapter",
+    "RuntimeFailureState",
     "RtspSourceAdapter",
+    "SourceInterruptedError",
     "build_source_adapter",
     "run_inference",
     "run_offline_mp4_inference",
+    "run_source_with_reconnect",
 ]

--- a/src/inference/__init__.py
+++ b/src/inference/__init__.py
@@ -6,7 +6,9 @@ from src.inference.json_writer import ActionEventWriter
 from src.inference.offline_runtime import (
     RuntimeFailureState,
     SourceInterruptedError,
+    run_source,
     run_source_with_reconnect,
+    run_video,
 )
 from src.inference.service import (
     InferenceServiceRequest,
@@ -37,5 +39,7 @@ __all__ = [
     "build_source_adapter",
     "run_inference",
     "run_offline_mp4_inference",
+    "run_source",
     "run_source_with_reconnect",
+    "run_video",
 ]

--- a/src/inference/offline_runtime.py
+++ b/src/inference/offline_runtime.py
@@ -312,8 +312,6 @@ def produce_frames_with_reconnect(
     finally:
         frame_queue.put(EOF_SENTINEL)
 
-    stats["frames_read_by_producer"] = frames_read
-
 
 def _interruptible_sleep(duration: float, stop_event: Optional[Event]) -> None:
     """Sleep for *duration* seconds, waking early if *stop_event* is set."""

--- a/src/inference/offline_runtime.py
+++ b/src/inference/offline_runtime.py
@@ -245,9 +245,6 @@ def produce_frames_with_reconnect(
                 attempts += 1
                 continue
 
-            # Successfully opened - reset retry counter for this connection.
-            attempts = 0
-            current_delay = retry_delay
             stop_requested = False
             connection_dropped = False
 
@@ -272,6 +269,10 @@ def produce_frames_with_reconnect(
                             frames_read,
                         )
                         break
+
+                    # Successfully read a frame - reset retry counter.
+                    attempts = 0
+                    current_delay = retry_delay
 
                     frames_read += 1
                     frame_queue.put(frame)

--- a/src/inference/offline_runtime.py
+++ b/src/inference/offline_runtime.py
@@ -39,7 +39,7 @@ class SourceInterruptedError(RuntimeError):
         self.frames_read = frames_read
 
 
-class RuntimeFailureState:
+class RuntimeFailureState(Exception):
     """Carries structured failure information from a failed runtime session.
 
     This is the controlled form in which lower-level errors are surfaced to
@@ -62,6 +62,7 @@ class RuntimeFailureState:
         """Initialise with error, phase, and frame count."""
         if phase not in {"producer", "consumer", "unknown"}:
             raise ValueError("phase must be 'producer', 'consumer', or 'unknown'")
+        super().__init__(f"Runtime failure in {phase} phase: {error}")
         self.error = error
         self.phase = phase
         self.frames_before_failure = frames_before_failure
@@ -371,7 +372,12 @@ def consume_frame_queue(
             break
 
         frame_count += 1
-        result = engine.process_frame(frame)
+        
+        try:
+            result = engine.process_frame(frame)
+        except Exception as exc:
+            stats["consumer_error"] = exc
+            break
 
         if result is not None:
             inference_results.append(result)
@@ -426,6 +432,7 @@ def run_source(
         "inference_count": 0,
         "inference_results": [],
         "producer_error": None,
+        "consumer_error": None,
     }
 
     producer = Thread(
@@ -446,7 +453,18 @@ def run_source(
     consumer.join()
 
     if stats["producer_error"] is not None:
-        raise stats["producer_error"]
+        raise RuntimeFailureState(
+            error=stats["producer_error"],
+            phase="producer",
+            frames_before_failure=stats["frame_count"],
+        ) from stats["producer_error"]
+        
+    if stats["consumer_error"] is not None:
+        raise RuntimeFailureState(
+            error=stats["consumer_error"],
+            phase="consumer",
+            frames_before_failure=stats["frame_count"],
+        ) from stats["consumer_error"]
 
     frame_count = stats["frame_count"]
     inference_count = stats["inference_count"]
@@ -516,6 +534,7 @@ def run_source_with_reconnect(
         "inference_count": 0,
         "inference_results": [],
         "producer_error": None,
+        "consumer_error": None,
     }
 
     producer = Thread(
@@ -541,7 +560,18 @@ def run_source_with_reconnect(
     consumer.join()
 
     if stats["producer_error"] is not None:
-        raise stats["producer_error"]
+        raise RuntimeFailureState(
+            error=stats["producer_error"],
+            phase="producer",
+            frames_before_failure=stats["frame_count"],
+        ) from stats["producer_error"]
+        
+    if stats["consumer_error"] is not None:
+        raise RuntimeFailureState(
+            error=stats["consumer_error"],
+            phase="consumer",
+            frames_before_failure=stats["frame_count"],
+        ) from stats["consumer_error"]
 
     frame_count = stats["frame_count"]
     inference_count = stats["inference_count"]

--- a/src/inference/offline_runtime.py
+++ b/src/inference/offline_runtime.py
@@ -1,7 +1,9 @@
 """Offline producer-consumer runtime for adapter-based inference inputs."""
+import logging
+import time
 from pathlib import Path
-from queue import Queue
-from threading import Thread
+from queue import Empty, Queue
+from threading import Event, Thread
 from typing import Any, Optional
 
 from src.inference.engine import InferenceEngine
@@ -9,18 +11,91 @@ from src.inference.json_writer import ActionEventWriter
 from src.inference.source_adapters import FileSourceAdapter, InferenceSourceAdapter
 from src.inference.tracker import BaseTracker, SingleTrackTracker
 
+logger = logging.getLogger(__name__)
+
 EOF_SENTINEL = object()
+
+# ---------------------------------------------------------------------------
+# Public exception and failure-state types
+# ---------------------------------------------------------------------------
+
+_RTSP_SOURCE_TYPES = {"rtsp"}
+
+
+class SourceInterruptedError(RuntimeError):
+    """Raised when an active source connection is lost mid-stream.
+
+    Attributes:
+        source_ref: The URI / path of the interrupted source.
+        frames_read: Number of frames successfully read before interruption.
+    """
+
+    def __init__(self, source_ref: str, frames_read: int = 0) -> None:
+        """Initialise with source reference and frames-read count."""
+        super().__init__(
+            f"Source interrupted after {frames_read} frame(s): {source_ref}"
+        )
+        self.source_ref = source_ref
+        self.frames_read = frames_read
+
+
+class RuntimeFailureState:
+    """Carries structured failure information from a failed runtime session.
+
+    This is the controlled form in which lower-level errors are surfaced to
+    higher layers (e.g. FastAPI backend) instead of letting raw exceptions
+    propagate unchecked.
+
+    Attributes:
+        error: The original exception that caused the failure.
+        phase: Which phase failed – ``"producer"``, ``"consumer"``, or
+            ``"unknown"``.
+        frames_before_failure: Frames processed successfully before failure.
+    """
+
+    def __init__(
+        self,
+        error: BaseException,
+        phase: str = "unknown",
+        frames_before_failure: int = 0,
+    ) -> None:
+        """Initialise with error, phase, and frame count."""
+        if phase not in {"producer", "consumer", "unknown"}:
+            raise ValueError("phase must be 'producer', 'consumer', or 'unknown'")
+        self.error = error
+        self.phase = phase
+        self.frames_before_failure = frames_before_failure
+
+    def __repr__(self) -> str:
+        """Return developer-readable representation."""
+        return (
+            f"RuntimeFailureState(phase={self.phase!r}, "
+            f"frames_before_failure={self.frames_before_failure}, "
+            f"error={self.error!r})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Producer helpers
+# ---------------------------------------------------------------------------
 
 
 def produce_frames_from_source(
     source_adapter: InferenceSourceAdapter,
     frame_queue: Queue,
+    stop_event: Optional[Event] = None,
 ) -> None:
-    """Reads frames from a source adapter in source order and pushes them to a queue.
+    """Read frames from a source adapter and push them to a queue.
+
+    Stops early when *stop_event* is set.  The EOF sentinel is always pushed
+    to the queue so the consumer can terminate cleanly.
 
     Args:
-        source_adapter (InferenceSourceAdapter): Source adapter to open and read.
+        source_adapter (InferenceSourceAdapter): Source adapter to open and
+            read.
         frame_queue (Queue): Queue used to pass frames to the consumer.
+        stop_event (Optional[Event]): When set, the producer stops reading
+            new frames and exits.
 
     Raises:
         RuntimeError: If the source cannot be opened.
@@ -34,13 +109,22 @@ def produce_frames_from_source(
                 f"{source_adapter.source_type} source: {source_adapter.source_ref}",
             )
 
+        frames_read = 0
         try:
             while True:
+                if stop_event is not None and stop_event.is_set():
+                    logger.debug(
+                        "Producer stopping early on stop_event (read %d frames).",
+                        frames_read,
+                    )
+                    break
+
                 ret, frame = cap.read()
 
                 if not ret:
                     break
 
+                frames_read += 1
                 frame_queue.put(frame)
         finally:
             cap.release()
@@ -61,27 +145,224 @@ def produce_frames_safe(
     source_adapter: InferenceSourceAdapter,
     frame_queue: Queue,
     stats: dict,
+    stop_event: Optional[Event] = None,
 ) -> None:
-    """Runs the frame producer and stores any raised exception in stats."""
+    """Run the frame producer and store any raised exception in stats."""
     try:
-        produce_frames_from_source(source_adapter, frame_queue)
+        produce_frames_from_source(source_adapter, frame_queue, stop_event=stop_event)
     except Exception as exc:
         stats["producer_error"] = exc
 
 
-def consume_frame_queue(frame_queue: Queue, engine: InferenceEngine, stats: dict) -> None:
-    """Consumes frames from a queue with an inference engine and updates runtime stats.
+# ---------------------------------------------------------------------------
+# RTSP reconnect producer
+# ---------------------------------------------------------------------------
+
+_DEFAULT_MAX_RETRIES = 5
+_DEFAULT_RETRY_DELAY = 2.0  # seconds
+_DEFAULT_BACKOFF_FACTOR = 2.0
+
+
+def produce_frames_with_reconnect(
+    source_adapter: InferenceSourceAdapter,
+    frame_queue: Queue,
+    stats: dict,
+    stop_event: Optional[Event] = None,
+    max_retries: int = _DEFAULT_MAX_RETRIES,
+    retry_delay: float = _DEFAULT_RETRY_DELAY,
+    backoff_factor: float = _DEFAULT_BACKOFF_FACTOR,
+) -> None:
+    """Frame producer with exponential back-off reconnect for stream sources.
+
+    On a ``cap.read()`` failure the producer waits *retry_delay* seconds (
+    doubling each attempt up to *max_retries*) before re-opening the source.
+    For non-stream sources (``source_type != 'rtsp'``) it falls back to
+    the standard single-attempt producer.
+
+    Args:
+        source_adapter (InferenceSourceAdapter): Source adapter to open and
+            read.
+        frame_queue (Queue): Queue used to pass frames to the consumer.
+        stats (dict): Mutable dict; ``producer_error`` is set on terminal
+            failure.
+        stop_event (Optional[Event]): When set the producer exits immediately.
+        max_retries (int): Maximum reconnect attempts before giving up.
+        retry_delay (float): Initial seconds to wait before the first retry.
+        backoff_factor (float): Multiplier applied to *retry_delay* on each
+            successive attempt.
+    """
+    if source_adapter.source_type not in _RTSP_SOURCE_TYPES:
+        # Non-stream sources do not need reconnect logic.
+        produce_frames_safe(source_adapter, frame_queue, stats, stop_event=stop_event)
+        return
+
+    frames_read = 0
+    attempts = 0
+    current_delay = retry_delay
+
+    try:
+        while True:
+            if stop_event is not None and stop_event.is_set():
+                logger.debug("Reconnect producer: stop_event set before attempt.")
+                break
+
+            try:
+                cap = source_adapter.open_capture()
+            except Exception as open_exc:
+                logger.warning(
+                    "Reconnect producer: open_capture() raised: %s", open_exc
+                )
+                cap = None
+
+            if cap is None or not cap.isOpened():
+                if cap is not None:
+                    cap.release()
+
+                if attempts >= max_retries:
+                    err = SourceInterruptedError(
+                        source_ref=source_adapter.source_ref,
+                        frames_read=frames_read,
+                    )
+                    logger.error(
+                        "Reconnect producer: max retries (%d) reached for %s.",
+                        max_retries,
+                        source_adapter.source_ref,
+                    )
+                    stats["producer_error"] = err
+                    return
+
+                logger.warning(
+                    "Reconnect producer: could not open source %s "
+                    "(attempt %d/%d), retrying in %.1fs.",
+                    source_adapter.source_ref,
+                    attempts + 1,
+                    max_retries,
+                    current_delay,
+                )
+                _interruptible_sleep(current_delay, stop_event)
+                current_delay *= backoff_factor
+                attempts += 1
+                continue
+
+            # Successfully opened – reset retry counter for this connection.
+            attempts = 0
+            current_delay = retry_delay
+            interrupted = False
+
+            try:
+                while True:
+                    if stop_event is not None and stop_event.is_set():
+                        logger.debug(
+                            "Reconnect producer: stop_event set (read %d frames).",
+                            frames_read,
+                        )
+                        interrupted = True
+                        break
+
+                    ret, frame = cap.read()
+                    if not ret:
+                        # Connection lost – will attempt reconnect below.
+                        interrupted = True
+                        logger.warning(
+                            "Reconnect producer: read() returned False for %s "
+                            "(frames read so far: %d). Will retry.",
+                            source_adapter.source_ref,
+                            frames_read,
+                        )
+                        break
+
+                    frames_read += 1
+                    frame_queue.put(frame)
+            finally:
+                cap.release()
+
+            if stop_event is not None and stop_event.is_set():
+                break
+
+            if not interrupted:
+                # Source ended cleanly (stream finished).
+                break
+
+            # Stream was interrupted – attempt reconnect.
+            if attempts >= max_retries:
+                err = SourceInterruptedError(
+                    source_ref=source_adapter.source_ref,
+                    frames_read=frames_read,
+                )
+                logger.error(
+                    "Reconnect producer: max retries (%d) exhausted for %s.",
+                    max_retries,
+                    source_adapter.source_ref,
+                )
+                stats["producer_error"] = err
+                return
+
+            logger.warning(
+                "Reconnect producer: scheduling reconnect for %s in %.1fs "
+                "(attempt %d/%d).",
+                source_adapter.source_ref,
+                current_delay,
+                attempts + 1,
+                max_retries,
+            )
+            _interruptible_sleep(current_delay, stop_event)
+            current_delay *= backoff_factor
+            attempts += 1
+
+    finally:
+        frame_queue.put(EOF_SENTINEL)
+
+    stats["frames_read_by_producer"] = frames_read
+
+
+def _interruptible_sleep(duration: float, stop_event: Optional[Event]) -> None:
+    """Sleep for *duration* seconds, waking early if *stop_event* is set."""
+    if stop_event is None:
+        time.sleep(duration)
+        return
+    stop_event.wait(timeout=duration)
+
+
+# ---------------------------------------------------------------------------
+# Consumer
+# ---------------------------------------------------------------------------
+
+
+def consume_frame_queue(
+    frame_queue: Queue,
+    engine: InferenceEngine,
+    stats: dict,
+    stop_event: Optional[Event] = None,
+) -> None:
+    """Consume frames from a queue with an inference engine and update stats.
 
     Args:
         frame_queue (Queue): Queue providing video frames.
         engine (InferenceEngine): Engine used to process frames.
         stats (dict): Mutable stats dictionary with frame and inference counts.
+        stop_event (Optional[Event]): When set the consumer discards remaining
+            queued frames and terminates as soon as the current item is
+            drained.
     """
     frame_count = 0
     inference_results = []
 
     while True:
-        frame = frame_queue.get()
+        if stop_event is not None and stop_event.is_set():
+            # Drain the queue without processing to unblock the producer.
+            try:
+                while True:
+                    item = frame_queue.get_nowait()
+                    if item is EOF_SENTINEL:
+                        break
+            except Empty:
+                pass
+            break
+
+        try:
+            frame = frame_queue.get(timeout=0.05)
+        except Empty:
+            continue
 
         if frame is EOF_SENTINEL:
             break
@@ -97,20 +378,30 @@ def consume_frame_queue(frame_queue: Queue, engine: InferenceEngine, stats: dict
     stats["inference_results"] = inference_results
 
 
+# ---------------------------------------------------------------------------
+# High-level runners
+# ---------------------------------------------------------------------------
+
+
 def run_source(
     source_adapter: InferenceSourceAdapter,
     engine: Optional[InferenceEngine] = None,
     tracker: Optional[BaseTracker] = None,
     emit_runtime_summary: bool = True,
+    stop_event: Optional[Event] = None,
 ) -> tuple[int, int, list[Any], list[Any]]:
-    """Runs offline inference on a generic source adapter.
+    """Run offline inference on a generic source adapter.
 
     Args:
         source_adapter: Adapter that provides inference input frames.
         engine: Optional inference engine instance. If None, a default
             InferenceEngine is created.
-        tracker: Optional tracker used to assign track IDs to inference results.
-        emit_runtime_summary: Whether to print processed frame/window/event stats.
+        tracker: Optional tracker used to assign track IDs to inference
+            results.
+        emit_runtime_summary: Whether to print processed frame/window/event
+            stats.
+        stop_event: Optional threading.Event; when set the producer and
+            consumer will stop early and the session will end gracefully.
 
     Returns:
         tuple[int, int, list[Any], list[Any]]: Number of processed frames,
@@ -126,18 +417,119 @@ def run_source(
     elif not isinstance(runtime_engine, InferenceEngine):
         raise TypeError("engine must be an InferenceEngine instance or None")
 
-    frame_queue = Queue()
-    stats = {
+    frame_queue: Queue = Queue()
+    stats: dict = {
         "frame_count": 0,
         "inference_count": 0,
         "inference_results": [],
         "producer_error": None,
     }
 
-    producer = Thread(target=produce_frames_safe,
-                      args=(source_adapter, frame_queue, stats))
-    consumer = Thread(target=consume_frame_queue,
-                      args=(frame_queue, runtime_engine, stats))
+    producer = Thread(
+        target=produce_frames_safe,
+        args=(source_adapter, frame_queue, stats),
+        kwargs={"stop_event": stop_event},
+    )
+    consumer = Thread(
+        target=consume_frame_queue,
+        args=(frame_queue, runtime_engine, stats),
+        kwargs={"stop_event": stop_event},
+    )
+
+    producer.start()
+    consumer.start()
+
+    producer.join()
+    consumer.join()
+
+    if stats["producer_error"] is not None:
+        raise stats["producer_error"]
+
+    frame_count = stats["frame_count"]
+    inference_count = stats["inference_count"]
+    inference_results = stats["inference_results"]
+
+    tracker = tracker or SingleTrackTracker()
+    track_ids = tracker.assign_track_ids(inference_results)
+
+    writer = ActionEventWriter()
+    writer.add_results(inference_results, track_ids=track_ids)
+    action_events = writer.get_log().events
+
+    if emit_runtime_summary:
+        print(f"Processed {frame_count} frames")
+        print(f"Generated {inference_count} inference windows")
+        print(f"Generated {len(action_events)} action events")
+
+    return frame_count, inference_count, inference_results, action_events
+
+
+def run_source_with_reconnect(
+    source_adapter: InferenceSourceAdapter,
+    engine: Optional[InferenceEngine] = None,
+    tracker: Optional[BaseTracker] = None,
+    emit_runtime_summary: bool = True,
+    stop_event: Optional[Event] = None,
+    max_retries: int = _DEFAULT_MAX_RETRIES,
+    retry_delay: float = _DEFAULT_RETRY_DELAY,
+    backoff_factor: float = _DEFAULT_BACKOFF_FACTOR,
+) -> tuple[int, int, list[Any], list[Any]]:
+    """Run inference with automatic reconnect for stream (RTSP) sources.
+
+    Behaves identically to :func:`run_source` for file sources.  For RTSP
+    sources the producer attempts to reconnect on read failures using
+    exponential back-off before giving up.
+
+    Args:
+        source_adapter: Adapter that provides inference input frames.
+        engine: Optional inference engine instance. If None, a default
+            InferenceEngine is created.
+        tracker: Optional tracker used to assign track IDs to inference
+            results.
+        emit_runtime_summary: Whether to print processed frame/window/event
+            stats.
+        stop_event: When set the session ends gracefully.
+        max_retries: Maximum reconnect attempts before raising
+            :exc:`SourceInterruptedError`.
+        retry_delay: Initial back-off delay in seconds.
+        backoff_factor: Multiplier applied to *retry_delay* on each attempt.
+
+    Returns:
+        tuple[int, int, list[Any], list[Any]]: Processed frames, inference
+        windows, inference results, and action events.
+    """
+    if not isinstance(source_adapter, InferenceSourceAdapter):
+        raise TypeError("source_adapter must be an InferenceSourceAdapter instance")
+
+    runtime_engine = engine
+    if runtime_engine is None:
+        runtime_engine = InferenceEngine()
+    elif not isinstance(runtime_engine, InferenceEngine):
+        raise TypeError("engine must be an InferenceEngine instance or None")
+
+    frame_queue: Queue = Queue()
+    stats: dict = {
+        "frame_count": 0,
+        "inference_count": 0,
+        "inference_results": [],
+        "producer_error": None,
+    }
+
+    producer = Thread(
+        target=produce_frames_with_reconnect,
+        args=(source_adapter, frame_queue, stats),
+        kwargs={
+            "stop_event": stop_event,
+            "max_retries": max_retries,
+            "retry_delay": retry_delay,
+            "backoff_factor": backoff_factor,
+        },
+    )
+    consumer = Thread(
+        target=consume_frame_queue,
+        args=(frame_queue, runtime_engine, stats),
+        kwargs={"stop_event": stop_event},
+    )
 
     producer.start()
     consumer.start()
@@ -172,8 +564,9 @@ def run_video(
     engine: Optional[InferenceEngine] = None,
     tracker: Optional[BaseTracker] = None,
     emit_runtime_summary: bool = True,
+    stop_event: Optional[Event] = None,
 ) -> tuple[int, int, list[Any], list[Any]]:
-    """Runs offline inference on a single local video file."""
+    """Run offline inference on a single local video file."""
     if not isinstance(video_path, str):
         raise TypeError("video_path must be a string")
 
@@ -183,4 +576,20 @@ def run_video(
         engine=engine,
         tracker=tracker,
         emit_runtime_summary=emit_runtime_summary,
+        stop_event=stop_event,
     )
+
+
+__all__ = [
+    "EOF_SENTINEL",
+    "RuntimeFailureState",
+    "SourceInterruptedError",
+    "consume_frame_queue",
+    "produce_frames",
+    "produce_frames_from_source",
+    "produce_frames_safe",
+    "produce_frames_with_reconnect",
+    "run_source",
+    "run_source_with_reconnect",
+    "run_video",
+]

--- a/src/inference/offline_runtime.py
+++ b/src/inference/offline_runtime.py
@@ -244,10 +244,11 @@ def produce_frames_with_reconnect(
                 attempts += 1
                 continue
 
-            # Successfully opened – reset retry counter for this connection.
+            # Successfully opened - reset retry counter for this connection.
             attempts = 0
             current_delay = retry_delay
-            interrupted = False
+            stop_requested = False
+            connection_dropped = False
 
             try:
                 while True:
@@ -256,13 +257,13 @@ def produce_frames_with_reconnect(
                             "Reconnect producer: stop_event set (read %d frames).",
                             frames_read,
                         )
-                        interrupted = True
+                        stop_requested = True
                         break
 
                     ret, frame = cap.read()
                     if not ret:
-                        # Connection lost – will attempt reconnect below.
-                        interrupted = True
+                        # Real read failure - reconnect logic will handle it.
+                        connection_dropped = True
                         logger.warning(
                             "Reconnect producer: read() returned False for %s "
                             "(frames read so far: %d). Will retry.",
@@ -276,14 +277,15 @@ def produce_frames_with_reconnect(
             finally:
                 cap.release()
 
-            if stop_event is not None and stop_event.is_set():
+            if stop_requested:
+                # Clean shutdown requested - do not reconnect.
                 break
 
-            if not interrupted:
+            if not connection_dropped:
                 # Source ended cleanly (stream finished).
                 break
 
-            # Stream was interrupted – attempt reconnect.
+            # Real connection drop - attempt reconnect.
             if attempts >= max_retries:
                 err = SourceInterruptedError(
                     source_ref=source_adapter.source_ref,

--- a/src/inference/offline_runtime.py
+++ b/src/inference/offline_runtime.py
@@ -103,14 +103,14 @@ def produce_frames_from_source(
     try:
         cap = source_adapter.open_capture()
 
-        if not cap.isOpened():
-            raise RuntimeError(
-                "Could not open "
-                f"{source_adapter.source_type} source: {source_adapter.source_ref}",
-            )
-
-        frames_read = 0
         try:
+            if not cap.isOpened():
+                raise RuntimeError(
+                    "Could not open "
+                    f"{source_adapter.source_type} source: {source_adapter.source_ref}",
+                )
+
+            frames_read = 0
             while True:
                 if stop_event is not None and stop_event.is_set():
                     logger.debug(

--- a/src/inference/offline_runtime.py
+++ b/src/inference/offline_runtime.py
@@ -349,14 +349,17 @@ def consume_frame_queue(
 
     while True:
         if stop_event is not None and stop_event.is_set():
-            # Drain the queue without processing to unblock the producer.
-            try:
-                while True:
-                    item = frame_queue.get_nowait()
-                    if item is EOF_SENTINEL:
-                        break
-            except Empty:
-                pass
+            # Drain the queue until the sentinel arrives.
+            while True:
+                try:
+                    # get_nowait() would exit early on a momentary Empty
+                    # and leave the sentinel unconsumed, blocking 
+                    # the producer on a bounded Queue.
+                    item = frame_queue.get(timeout=0.05) 
+                except Empty:
+                    continue
+                if item is EOF_SENTINEL:
+                    break
             break
 
         try:

--- a/src/inference/service.py
+++ b/src/inference/service.py
@@ -8,7 +8,8 @@ import torch
 from src.inference.action_event import ActionEvent
 from src.inference.engine import InferenceEngine, InferenceResult
 from src.inference.json_writer import ActionEventWriter
-from src.inference.offline_runtime import run_source
+from src.inference.offline_runtime import run_source_with_reconnect
+from threading import Event
 from src.inference.runtime import (
     InferenceRuntimeSettings,
     WindowModelAdapter,
@@ -55,7 +56,10 @@ class InferenceServiceResult:
         return len(self.action_events)
 
 
-def run_inference(request: InferenceServiceRequest) -> InferenceServiceResult:
+def run_inference(
+    request: InferenceServiceRequest,
+    stop_event: Event | None = None,
+) -> InferenceServiceResult:
     """Run inference and return typed in-memory results."""
     if not isinstance(request, InferenceServiceRequest):
         raise TypeError("request must be an InferenceServiceRequest instance")
@@ -82,10 +86,11 @@ def run_inference(request: InferenceServiceRequest) -> InferenceServiceResult:
         model=model_adapter,
     )
 
-    frame_count, inference_count, inference_results, _ = run_source(
+    frame_count, inference_count, inference_results, _ = run_source_with_reconnect(
         source_adapter=source_adapter,
         engine=engine,
         emit_runtime_summary=False,
+        stop_event=stop_event,
     )
     expanded_results = expand_batched_inference_results(inference_results)
     track_ids = build_track_ids(expanded_results, settings.default_track_id)

--- a/src/inference/service.py
+++ b/src/inference/service.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
+from threading import Event
 
 import torch
 
@@ -9,7 +10,6 @@ from src.inference.action_event import ActionEvent
 from src.inference.engine import InferenceEngine, InferenceResult
 from src.inference.json_writer import ActionEventWriter
 from src.inference.offline_runtime import run_source_with_reconnect
-from threading import Event
 from src.inference.runtime import (
     InferenceRuntimeSettings,
     WindowModelAdapter,

--- a/tests/inference/test_runtime_reliability.py
+++ b/tests/inference/test_runtime_reliability.py
@@ -1,0 +1,649 @@
+"""Tests for runtime reliability: interruption, shutdown, reconnect, failure surfacing."""
+from __future__ import annotations
+
+import threading
+from queue import Queue
+from threading import Event
+from typing import List, Optional
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from src.inference.engine import InferenceEngine
+from src.inference.offline_runtime import (
+    EOF_SENTINEL,
+    RuntimeFailureState,
+    SourceInterruptedError,
+    _interruptible_sleep,
+    consume_frame_queue,
+    produce_frames_from_source,
+    produce_frames_safe,
+    produce_frames_with_reconnect,
+    run_source,
+    run_source_with_reconnect,
+)
+from src.inference.source_adapters import RtspSourceAdapter
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+class _DummyModel:
+    def __call__(self, window):
+        return {"label": "action", "confidence": 0.9}
+
+
+def _make_frames(n: int = 10) -> List[np.ndarray]:
+    return [np.full((64, 64, 3), fill_value=i, dtype=np.uint8) for i in range(n)]
+
+
+class _FakeCapture:
+    """Fake cv2.VideoCapture that returns a fixed sequence of frames."""
+
+    def __init__(self, frames: List[np.ndarray], opened: bool = True) -> None:
+        self._frames = list(frames)
+        self._opened = opened
+        self.released = False
+
+    def isOpened(self) -> bool:  # noqa: N802
+        return self._opened
+
+    def read(self):
+        if not self._frames:
+            return False, None
+        return True, self._frames.pop(0)
+
+    def release(self) -> None:
+        self.released = True
+
+
+def _patch_capture(monkeypatch, frames: List[np.ndarray]) -> dict:
+    """Monkeypatch cv2.VideoCapture to return _FakeCapture(frames)."""
+    state: dict = {}
+
+    def _fake(source_ref):
+        cap = _FakeCapture(list(frames))
+        state["capture"] = cap
+        state["source_ref"] = source_ref
+        return cap
+
+    monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# SourceInterruptedError
+# ---------------------------------------------------------------------------
+
+
+class TestSourceInterruptedError:
+    def test_message_contains_source_ref_and_frame_count(self):
+        err = SourceInterruptedError(source_ref="rtsp://host/live", frames_read=42)
+        assert "rtsp://host/live" in str(err)
+        assert "42" in str(err)
+
+    def test_attributes_accessible(self):
+        err = SourceInterruptedError(source_ref="rtsp://host/live", frames_read=7)
+        assert err.source_ref == "rtsp://host/live"
+        assert err.frames_read == 7
+
+    def test_is_runtime_error(self):
+        err = SourceInterruptedError("rtsp://x", 0)
+        assert isinstance(err, RuntimeError)
+
+
+# ---------------------------------------------------------------------------
+# RuntimeFailureState
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeFailureState:
+    def test_stores_error_and_phase(self):
+        exc = ValueError("boom")
+        state = RuntimeFailureState(error=exc, phase="producer", frames_before_failure=5)
+        assert state.error is exc
+        assert state.phase == "producer"
+        assert state.frames_before_failure == 5
+
+    def test_repr_includes_phase(self):
+        exc = RuntimeError("x")
+        state = RuntimeFailureState(error=exc, phase="consumer")
+        assert "consumer" in repr(state)
+
+    def test_invalid_phase_raises(self):
+        with pytest.raises(ValueError):
+            RuntimeFailureState(error=RuntimeError(), phase="invalid_phase")
+
+    def test_valid_phases_accepted(self):
+        for phase in ("producer", "consumer", "unknown"):
+            RuntimeFailureState(error=Exception(), phase=phase)
+
+
+# ---------------------------------------------------------------------------
+# produce_frames_from_source – stop_event support
+# ---------------------------------------------------------------------------
+
+
+class TestProduceFramesFromSourceStopEvent:
+    def test_stop_event_halts_producer_before_all_frames(self, monkeypatch):
+        frames = _make_frames(20)
+        stop = Event()
+        queue: Queue = Queue()
+
+        call_count = [0]
+
+        class _SlowCapture(_FakeCapture):
+            def read(self):
+                call_count[0] += 1
+                if call_count[0] == 5:
+                    stop.set()
+                return super().read()
+
+        def _fake(source_ref):
+            return _SlowCapture(list(frames))
+
+        monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake)
+
+        adapter = RtspSourceAdapter(rtsp_uri="rtsp://host/stream")
+        produce_frames_from_source(adapter, queue, stop_event=stop)
+
+        items = []
+        while not queue.empty():
+            items.append(queue.get_nowait())
+
+        # EOF sentinel must always be present.
+        assert items[-1] is EOF_SENTINEL
+        # Producer was cut short.
+        assert len(items) < len(frames) + 1  # +1 for sentinel
+
+    def test_no_stop_event_reads_all_frames(self, monkeypatch):
+        frames = _make_frames(8)
+        state = _patch_capture(monkeypatch, frames)
+        queue: Queue = Queue()
+
+        adapter = RtspSourceAdapter(rtsp_uri="rtsp://host/stream")
+        produce_frames_from_source(adapter, queue, stop_event=None)
+
+        items = []
+        while not queue.empty():
+            items.append(queue.get_nowait())
+
+        frame_items = [i for i in items if i is not EOF_SENTINEL]
+        assert len(frame_items) == 8
+        assert items[-1] is EOF_SENTINEL
+        assert state["capture"].released is True
+
+    def test_capture_always_released_even_on_stop(self, monkeypatch):
+        frames = _make_frames(10)
+        stop = Event()
+        stop.set()  # stopped before even starting
+        queue: Queue = Queue()
+
+        captured_cap: dict = {}
+
+        def _fake(source_ref):
+            cap = _FakeCapture(list(frames))
+            captured_cap["cap"] = cap
+            return cap
+
+        monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake)
+        adapter = RtspSourceAdapter(rtsp_uri="rtsp://host/stream")
+        produce_frames_from_source(adapter, queue, stop_event=stop)
+
+        assert captured_cap["cap"].released is True
+
+    def test_eof_sentinel_always_enqueued_on_open_failure(self, monkeypatch):
+        def _fake(_):
+            return _FakeCapture([], opened=False)
+
+        monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake)
+        adapter = RtspSourceAdapter(rtsp_uri="rtsp://host/stream")
+        queue: Queue = Queue()
+
+        with pytest.raises(RuntimeError, match="Could not open"):
+            produce_frames_from_source(adapter, queue)
+
+        # Sentinel must still be present.
+        assert queue.get_nowait() is EOF_SENTINEL
+
+
+# ---------------------------------------------------------------------------
+# consume_frame_queue – stop_event support
+# ---------------------------------------------------------------------------
+
+
+class TestConsumeFrameQueueStopEvent:
+    def test_stop_event_drains_queue_and_exits(self):
+        queue: Queue = Queue()
+        frames = _make_frames(20)
+        for f in frames:
+            queue.put(f)
+        queue.put(EOF_SENTINEL)
+
+        stop = Event()
+        stop.set()
+
+        engine = InferenceEngine(model=_DummyModel())
+        stats: dict = {}
+        consume_frame_queue(queue, engine, stats, stop_event=stop)
+
+        # Consumer must have exited and written stats.
+        assert "frame_count" in stats
+        # Because stop was already set, no frames should have been processed.
+        assert stats["frame_count"] == 0
+
+    def test_without_stop_event_processes_all_frames(self):
+        queue: Queue = Queue()
+        frames = _make_frames(10)
+        for f in frames:
+            queue.put(f)
+        queue.put(EOF_SENTINEL)
+
+        engine = InferenceEngine(window_size=4, stride=2, model=_DummyModel())
+        stats: dict = {}
+        consume_frame_queue(queue, engine, stats)
+
+        assert stats["frame_count"] == 10
+
+    def test_stop_event_set_mid_stream_terminates(self):
+        """Consumer terminates when stop_event is set while consuming."""
+        queue: Queue = Queue()
+        stop = Event()
+
+        def _producer():
+            for i in range(100):
+                if stop.is_set():
+                    break
+                queue.put(np.zeros((64, 64, 3), dtype=np.uint8))
+            queue.put(EOF_SENTINEL)
+
+        t = threading.Thread(target=_producer)
+        t.start()
+
+        engine = InferenceEngine(window_size=4, stride=2, model=_DummyModel())
+        stats: dict = {}
+
+        def _trigger_stop():
+            # Let a few frames flow through before stopping.
+            threading.Event().wait(timeout=0.02)
+            stop.set()
+
+        stopper = threading.Thread(target=_trigger_stop)
+        stopper.start()
+
+        consume_frame_queue(queue, engine, stats, stop_event=stop)
+
+        t.join(timeout=2)
+        stopper.join(timeout=1)
+
+        # Consumer exited – frame_count must be set.
+        assert "frame_count" in stats
+
+
+# ---------------------------------------------------------------------------
+# produce_frames_with_reconnect
+# ---------------------------------------------------------------------------
+
+
+class TestProduceFramesWithReconnect:
+    def _make_rtsp_adapter(self) -> RtspSourceAdapter:
+        return RtspSourceAdapter(rtsp_uri="rtsp://host/live")
+
+    def test_non_rtsp_falls_back_to_simple_producer(self, monkeypatch, tmp_path):
+        """File sources bypass reconnect logic."""
+        video_path = tmp_path / "sample.mp4"
+        frames = _make_frames(6)
+
+        called_open: list = []
+
+        class _CapWithTracking(_FakeCapture):
+            pass
+
+        def _fake(source_ref):
+            called_open.append(source_ref)
+            return _CapWithTracking(list(frames))
+
+        monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake)
+
+        from src.inference.source_adapters import FileSourceAdapter
+
+        video_path.write_bytes(b"\x00" * 100)
+        # FileSourceAdapter validates file existence; write bytes first.
+        adapter = FileSourceAdapter(video_path=video_path)
+        queue: Queue = Queue()
+        stats: dict = {"producer_error": None}
+
+        produce_frames_with_reconnect(adapter, queue, stats)
+
+        # EOF sentinel must be present.
+        items = []
+        while not queue.empty():
+            items.append(queue.get_nowait())
+        assert items[-1] is EOF_SENTINEL
+
+    def test_reconnects_after_read_failure(self, monkeypatch):
+        """Producer reconnects once when the stream drops mid-read."""
+        adapter = self._make_rtsp_adapter()
+
+        open_calls: list = []
+        frames_batch1 = _make_frames(5)
+        frames_batch2 = _make_frames(5)
+
+        def _fake(_source_ref):
+            call_no = len(open_calls)
+            open_calls.append(call_no)
+            if call_no == 0:
+                # First connection: returns 5 frames then drops.
+                return _FakeCapture(list(frames_batch1))
+            # Second connection: returns 5 clean frames.
+            return _FakeCapture(list(frames_batch2))
+
+        monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake)
+
+        queue: Queue = Queue()
+        stats: dict = {"producer_error": None}
+
+        produce_frames_with_reconnect(
+            adapter,
+            queue,
+            stats,
+            retry_delay=0.001,
+            backoff_factor=1.0,
+            max_retries=3,
+        )
+
+        items = []
+        while not queue.empty():
+            items.append(queue.get_nowait())
+
+        frame_items = [i for i in items if i is not EOF_SENTINEL]
+        assert len(frame_items) == 10  # 5 from batch1 + 5 from batch2
+        assert items[-1] is EOF_SENTINEL
+        assert len(open_calls) == 2
+        assert stats["producer_error"] is None
+
+    def test_raises_source_interrupted_after_max_retries(self, monkeypatch):
+        """Producer gives up after max_retries and sets producer_error."""
+        adapter = self._make_rtsp_adapter()
+
+        def _fake(_source_ref):
+            return _FakeCapture([], opened=False)
+
+        monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake)
+
+        queue: Queue = Queue()
+        stats: dict = {"producer_error": None}
+
+        produce_frames_with_reconnect(
+            adapter,
+            queue,
+            stats,
+            retry_delay=0.001,
+            backoff_factor=1.0,
+            max_retries=2,
+        )
+
+        # EOF sentinel always pushed.
+        sentinel = queue.get_nowait()
+        assert sentinel is EOF_SENTINEL
+        assert isinstance(stats["producer_error"], SourceInterruptedError)
+
+    def test_stop_event_aborts_reconnect_sleep(self, monkeypatch):
+        """Setting stop_event during the retry sleep causes early exit."""
+        adapter = self._make_rtsp_adapter()
+        stop = Event()
+
+        def _fake(_source_ref):
+            stop.set()  # trigger stop on every open attempt
+            return _FakeCapture([], opened=False)
+
+        monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake)
+
+        queue: Queue = Queue()
+        stats: dict = {"producer_error": None}
+
+        produce_frames_with_reconnect(
+            adapter,
+            queue,
+            stats,
+            stop_event=stop,
+            retry_delay=10.0,  # would hang if sleep isn't interrupted
+            max_retries=5,
+        )
+
+        # Should finish quickly without sleeping the full 10 s.
+        assert queue.get_nowait() is EOF_SENTINEL
+
+    def test_stop_event_set_before_start_exits_immediately(self, monkeypatch):
+        adapter = self._make_rtsp_adapter()
+        stop = Event()
+        stop.set()
+
+        open_calls: list = []
+
+        def _fake(_):
+            open_calls.append(1)
+            return _FakeCapture(_make_frames(10))
+
+        monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake)
+
+        queue: Queue = Queue()
+        stats: dict = {"producer_error": None}
+
+        produce_frames_with_reconnect(adapter, queue, stats, stop_event=stop)
+
+        # No open should have been attempted (stop was already set).
+        assert open_calls == []
+        assert queue.get_nowait() is EOF_SENTINEL
+
+
+# ---------------------------------------------------------------------------
+# run_source – stop_event integration
+# ---------------------------------------------------------------------------
+
+
+class TestRunSourceStopEvent:
+    def test_stop_event_terminates_session_gracefully(self, monkeypatch):
+        frames = _make_frames(50)
+        stop = Event()
+        call_count = [0]
+
+        def _fake(_source_ref):
+            class _SlowCap(_FakeCapture):
+                def read(self_inner):
+                    call_count[0] += 1
+                    if call_count[0] == 10:
+                        stop.set()
+                    return super().read()
+
+            return _SlowCap(list(frames))
+
+        monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake)
+
+        adapter = RtspSourceAdapter(rtsp_uri="rtsp://host/stream")
+        engine = InferenceEngine(window_size=4, stride=2, model=_DummyModel())
+
+        frame_count, *_ = run_source(
+            source_adapter=adapter,
+            engine=engine,
+            emit_runtime_summary=False,
+            stop_event=stop,
+        )
+
+        # Less than all 50 frames were processed.
+        assert frame_count < 50
+
+    def test_run_source_producer_error_surfaces_as_exception(self, monkeypatch):
+        def _fake(_source_ref):
+            return _FakeCapture([], opened=False)
+
+        monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake)
+
+        adapter = RtspSourceAdapter(rtsp_uri="rtsp://host/stream")
+        engine = InferenceEngine(model=_DummyModel())
+
+        with pytest.raises(RuntimeError, match="Could not open"):
+            run_source(source_adapter=adapter, engine=engine, emit_runtime_summary=False)
+
+
+# ---------------------------------------------------------------------------
+# run_source_with_reconnect
+# ---------------------------------------------------------------------------
+
+
+class TestRunSourceWithReconnect:
+    def test_reconnect_runner_returns_results_after_reconnect(self, monkeypatch):
+        open_calls: list = []
+        frames_a = _make_frames(4)
+        frames_b = _make_frames(4)
+
+        def _fake(_source_ref):
+            n = len(open_calls)
+            open_calls.append(n)
+            if n == 0:
+                return _FakeCapture(list(frames_a))
+            return _FakeCapture(list(frames_b))
+
+        monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake)
+
+        adapter = RtspSourceAdapter(rtsp_uri="rtsp://host/stream")
+        engine = InferenceEngine(window_size=4, stride=2, model=_DummyModel())
+
+        frame_count, inference_count, results, events = run_source_with_reconnect(
+            source_adapter=adapter,
+            engine=engine,
+            emit_runtime_summary=False,
+            retry_delay=0.001,
+            backoff_factor=1.0,
+            max_retries=3,
+        )
+
+        assert frame_count == 8
+        assert inference_count > 0
+
+    def test_reconnect_runner_raises_on_exhausted_retries(self, monkeypatch):
+        def _fake(_):
+            return _FakeCapture([], opened=False)
+
+        monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake)
+
+        adapter = RtspSourceAdapter(rtsp_uri="rtsp://host/stream")
+        engine = InferenceEngine(model=_DummyModel())
+
+        with pytest.raises(SourceInterruptedError):
+            run_source_with_reconnect(
+                source_adapter=adapter,
+                engine=engine,
+                emit_runtime_summary=False,
+                retry_delay=0.001,
+                max_retries=1,
+            )
+
+    def test_stop_event_terminates_reconnect_runner(self, monkeypatch):
+        stop = Event()
+        stop.set()
+
+        def _fake(_):
+            return _FakeCapture(_make_frames(100))
+
+        monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake)
+
+        adapter = RtspSourceAdapter(rtsp_uri="rtsp://host/stream")
+        engine = InferenceEngine(model=_DummyModel())
+
+        frame_count, *_ = run_source_with_reconnect(
+            source_adapter=adapter,
+            engine=engine,
+            emit_runtime_summary=False,
+            stop_event=stop,
+        )
+        assert frame_count == 0
+
+
+# ---------------------------------------------------------------------------
+# _interruptible_sleep
+# ---------------------------------------------------------------------------
+
+
+class TestInterruptibleSleep:
+    def test_returns_early_when_event_set(self):
+        stop = Event()
+        stop.set()
+        import time
+
+        start = time.monotonic()
+        _interruptible_sleep(5.0, stop)
+        elapsed = time.monotonic() - start
+        assert elapsed < 1.0  # should not wait 5 s
+
+    def test_sleeps_full_duration_when_event_not_set(self):
+        stop = Event()
+        import time
+
+        start = time.monotonic()
+        _interruptible_sleep(0.05, stop)
+        elapsed = time.monotonic() - start
+        assert elapsed >= 0.04
+
+    def test_works_without_event(self):
+        import time
+
+        start = time.monotonic()
+        _interruptible_sleep(0.05, None)
+        elapsed = time.monotonic() - start
+        assert elapsed >= 0.04
+
+
+# ---------------------------------------------------------------------------
+# produce_frames_safe backward-compat
+# ---------------------------------------------------------------------------
+
+
+class TestProduceFramesSafe:
+    def test_stores_exception_in_stats(self, monkeypatch):
+        def _fake(_):
+            return _FakeCapture([], opened=False)
+
+        monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake)
+
+        adapter = RtspSourceAdapter(rtsp_uri="rtsp://host/stream")
+        queue: Queue = Queue()
+        stats: dict = {"producer_error": None}
+        produce_frames_safe(adapter, queue, stats)
+
+        assert isinstance(stats["producer_error"], RuntimeError)
+        # Sentinel still queued.
+        assert queue.get_nowait() is EOF_SENTINEL
+
+    def test_respects_stop_event(self, monkeypatch):
+        frames = _make_frames(20)
+        stop = Event()
+
+        call_count = [0]
+
+        def _fake(_):
+            class _Cap(_FakeCapture):
+                def read(self_inner):
+                    call_count[0] += 1
+                    if call_count[0] == 3:
+                        stop.set()
+                    return super().read()
+
+            return _Cap(list(frames))
+
+        monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake)
+
+        adapter = RtspSourceAdapter(rtsp_uri="rtsp://host/stream")
+        queue: Queue = Queue()
+        stats: dict = {"producer_error": None}
+        produce_frames_safe(adapter, queue, stats, stop_event=stop)
+
+        items = []
+        while not queue.empty():
+            items.append(queue.get_nowait())
+
+        assert items[-1] is EOF_SENTINEL
+        assert len(items) < len(frames) + 1

--- a/tests/inference/test_runtime_reliability.py
+++ b/tests/inference/test_runtime_reliability.py
@@ -11,19 +11,18 @@ import pytest
 
 from src.inference.engine import InferenceEngine
 from src.inference.offline_runtime import (
+    EOF_SENTINEL,
+    RuntimeFailureState,
+    SourceInterruptedError,
     _interruptible_sleep,
     consume_frame_queue,
-    EOF_SENTINEL,
     produce_frames_from_source,
     produce_frames_safe,
     produce_frames_with_reconnect,
     run_source,
     run_source_with_reconnect,
-    RuntimeFailureState,
-    SourceInterruptedError,
 )
 from src.inference.source_adapters import RtspSourceAdapter
-
 
 # ---------------------------------------------------------------------------
 # Shared helpers

--- a/tests/inference/test_runtime_reliability.py
+++ b/tests/inference/test_runtime_reliability.py
@@ -497,8 +497,11 @@ class TestRunSourceStopEvent:
         adapter = RtspSourceAdapter(rtsp_uri="rtsp://host/stream")
         engine = InferenceEngine(model=_DummyModel())
 
-        with pytest.raises(RuntimeError, match="Could not open"):
+        with pytest.raises(RuntimeFailureState, match="Could not open") as exc_info:
             run_source(source_adapter=adapter, engine=engine, emit_runtime_summary=False)
+            
+        assert exc_info.value.phase == "producer"
+        assert isinstance(exc_info.value.error, RuntimeError)
 
 
 # ---------------------------------------------------------------------------
@@ -551,7 +554,7 @@ class TestRunSourceWithReconnect:
         adapter = RtspSourceAdapter(rtsp_uri="rtsp://host/stream")
         engine = InferenceEngine(model=_DummyModel())
 
-        with pytest.raises(SourceInterruptedError):
+        with pytest.raises(RuntimeFailureState) as exc_info:
             run_source_with_reconnect(
                 source_adapter=adapter,
                 engine=engine,
@@ -559,6 +562,9 @@ class TestRunSourceWithReconnect:
                 retry_delay=0.001,
                 max_retries=1,
             )
+            
+        assert exc_info.value.phase == "producer"
+        assert isinstance(exc_info.value.error, SourceInterruptedError)
 
     def test_stop_event_terminates_reconnect_runner(self, monkeypatch):
         stop = Event()

--- a/tests/inference/test_runtime_reliability.py
+++ b/tests/inference/test_runtime_reliability.py
@@ -401,6 +401,36 @@ class TestProduceFramesWithReconnect:
         assert sentinel is EOF_SENTINEL
         assert isinstance(stats["producer_error"], SourceInterruptedError)
 
+    def test_reconnect_fails_if_read_repeatedly_fails_after_open(self, monkeypatch):
+        """Producer gives up if open succeeds but read immediately fails max_retries times."""
+        adapter = self._make_rtsp_adapter()
+        
+        open_calls: list = []
+
+        def _fake(_source_ref):
+            open_calls.append(1)
+            # isOpened() is True, but read() returns False immediately
+            return _FakeCapture([], opened=True)
+
+        monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake)
+
+        queue: Queue = Queue()
+        stats: dict = {"producer_error": None}
+
+        produce_frames_with_reconnect(
+            adapter,
+            queue,
+            stats,
+            retry_delay=0.001,
+            backoff_factor=1.0,
+            max_retries=3,
+        )
+
+        assert len(open_calls) == 4 # Initial + 3 retries
+        assert isinstance(stats["producer_error"], SourceInterruptedError)
+        sentinel = queue.get_nowait()
+        assert sentinel is EOF_SENTINEL
+
     def test_stop_event_aborts_reconnect_sleep(self, monkeypatch):
         """Setting stop_event during the retry sleep causes early exit."""
         adapter = self._make_rtsp_adapter()

--- a/tests/inference/test_runtime_reliability.py
+++ b/tests/inference/test_runtime_reliability.py
@@ -336,6 +336,7 @@ class TestProduceFramesWithReconnect:
         open_calls: list = []
         frames_batch1 = _make_frames(5)
         frames_batch2 = _make_frames(5)
+        stop = Event()
 
         def _fake(_source_ref):
             call_no = len(open_calls)
@@ -343,8 +344,13 @@ class TestProduceFramesWithReconnect:
             if call_no == 0:
                 # First connection: returns 5 frames then drops.
                 return _FakeCapture(list(frames_batch1))
-            # Second connection: returns 5 clean frames.
-            return _FakeCapture(list(frames_batch2))
+            if call_no == 1:
+                # Second connection: returns 5 frames then drops.
+                return _FakeCapture(list(frames_batch2))
+            
+            # Stop the loop after second connection drops
+            stop.set()
+            return _FakeCapture([], opened=False)
 
         monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake)
 
@@ -355,6 +361,7 @@ class TestProduceFramesWithReconnect:
             adapter,
             queue,
             stats,
+            stop_event=stop,
             retry_delay=0.001,
             backoff_factor=1.0,
             max_retries=3,
@@ -367,7 +374,7 @@ class TestProduceFramesWithReconnect:
         frame_items = [i for i in items if i is not EOF_SENTINEL]
         assert len(frame_items) == 10  # 5 from batch1 + 5 from batch2
         assert items[-1] is EOF_SENTINEL
-        assert len(open_calls) == 2
+        assert len(open_calls) == 3
         assert stats["producer_error"] is None
 
     def test_raises_source_interrupted_after_max_retries(self, monkeypatch):
@@ -504,13 +511,18 @@ class TestRunSourceWithReconnect:
         open_calls: list = []
         frames_a = _make_frames(4)
         frames_b = _make_frames(4)
+        stop = Event()
 
         def _fake(_source_ref):
             n = len(open_calls)
             open_calls.append(n)
             if n == 0:
                 return _FakeCapture(list(frames_a))
-            return _FakeCapture(list(frames_b))
+            if n == 1:
+                return _FakeCapture(list(frames_b))
+            
+            stop.set()
+            return _FakeCapture([], opened=False)
 
         monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake)
 
@@ -521,6 +533,7 @@ class TestRunSourceWithReconnect:
             source_adapter=adapter,
             engine=engine,
             emit_runtime_summary=False,
+            stop_event=stop,
             retry_delay=0.001,
             backoff_factor=1.0,
             max_retries=3,

--- a/tests/inference/test_runtime_reliability.py
+++ b/tests/inference/test_runtime_reliability.py
@@ -4,24 +4,23 @@ from __future__ import annotations
 import threading
 from queue import Queue
 from threading import Event
-from typing import List, Optional
-from unittest.mock import MagicMock
+from typing import List
 
 import numpy as np
 import pytest
 
 from src.inference.engine import InferenceEngine
 from src.inference.offline_runtime import (
-    EOF_SENTINEL,
-    RuntimeFailureState,
-    SourceInterruptedError,
     _interruptible_sleep,
     consume_frame_queue,
+    EOF_SENTINEL,
     produce_frames_from_source,
     produce_frames_safe,
     produce_frames_with_reconnect,
     run_source,
     run_source_with_reconnect,
+    RuntimeFailureState,
+    SourceInterruptedError,
 )
 from src.inference.source_adapters import RtspSourceAdapter
 

--- a/tests/inference/test_runtime_reliability.py
+++ b/tests/inference/test_runtime_reliability.py
@@ -196,8 +196,12 @@ class TestProduceFramesFromSourceStopEvent:
         assert captured_cap["cap"].released is True
 
     def test_eof_sentinel_always_enqueued_on_open_failure(self, monkeypatch):
+        captured_cap = {}
+
         def _fake(_):
-            return _FakeCapture([], opened=False)
+            cap = _FakeCapture([], opened=False)
+            captured_cap["cap"] = cap
+            return cap
 
         monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake)
         adapter = RtspSourceAdapter(rtsp_uri="rtsp://host/stream")
@@ -208,6 +212,7 @@ class TestProduceFramesFromSourceStopEvent:
 
         # Sentinel must still be present.
         assert queue.get_nowait() is EOF_SENTINEL
+        assert captured_cap["cap"].released is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/inference/test_service.py
+++ b/tests/inference/test_service.py
@@ -1,12 +1,13 @@
+from threading import Event
+
 import numpy as np
 import pytest
 import torch
 import yaml
-from threading import Event
 
 from src.inference.service import (
-    InferenceServiceRequest,
     _build_request_source_adapter,
+    InferenceServiceRequest,
     run_inference,
     run_offline_mp4_inference,
 )

--- a/tests/inference/test_service.py
+++ b/tests/inference/test_service.py
@@ -6,8 +6,8 @@ import torch
 import yaml
 
 from src.inference.service import (
-    _build_request_source_adapter,
     InferenceServiceRequest,
+    _build_request_source_adapter,
     run_inference,
     run_offline_mp4_inference,
 )

--- a/tests/inference/test_service.py
+++ b/tests/inference/test_service.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import torch
 import yaml
+from threading import Event
 
 from src.inference.service import (
     InferenceServiceRequest,
@@ -83,16 +84,21 @@ def test_run_inference_processes_rtsp_frames_with_runtime(monkeypatch, tmp_path)
 
         def read(self):
             if not self._frames:
+                import time
+                time.sleep(0.1)
+                stop.set()
                 return False, None
             return True, self._frames.pop(0)
 
         def release(self):
             self.released = True
 
+    stop = Event()
     def _fake_video_capture(source_ref):
         capture = _FakeCapture(source_ref)
         capture_state["source_ref"] = source_ref
         capture_state["capture"] = capture
+        
         return capture
 
     monkeypatch.setattr("src.inference.source_adapters.cv2.VideoCapture", _fake_video_capture)
@@ -104,7 +110,7 @@ def test_run_inference_processes_rtsp_frames_with_runtime(monkeypatch, tmp_path)
         source_type="rtsp",
         source_uri="rtsp://camera.local/stream",
     )
-    result = run_inference(request)
+    result = run_inference(request, stop_event=stop)
 
     assert capture_state["source_ref"] == "rtsp://camera.local/stream"
     assert capture_state["capture"].released is True


### PR DESCRIPTION
## Summary
This PR implements robust reliability controls for the offline inference runtime, explicitly addressing graceful shutdown paths, automatic reconnection for RTSP stream disruptions, and the reliable surfacing of session failures to higher integration layers (e.g. FastAPI backend).

Key enhancements and fixes:
- **Stream Reconnection Support:** Upgraded [`run_inference`](https://github.com/lukaszjecek/human-behavior-recognition-in-video-streams/blob/74-feature-handle-stream-interruption-and-graceful-reconnect-in-runtime/src/inference/service.py) to utilize `run_source_with_reconnect` and accept a `stop_event`. RTSP streams will now automatically attempt exponential back-off reconnection upon a connection drop.
- **Graceful Shutdown & Deadlock Prevention:** Separated termination signaling into `stop_requested` and `connection_dropped` logic. Overhauled the [consumer drain loop](https://github.com/lukaszjecek/human-behavior-recognition-in-video-streams/blob/74-feature-handle-stream-interruption-and-graceful-reconnect-in-runtime/src/inference/offline_runtime.py) using bounded timeouts so that it always explicitly consumes the `EOF_SENTINEL`, guaranteeing a clean exit without deadlocking the producer.
- **Structured Failure Surfacing:** Converted [`RuntimeFailureState`](https://github.com/lukaszjecek/human-behavior-recognition-in-video-streams/blob/74-feature-handle-stream-interruption-and-graceful-reconnect-in-runtime/src/inference/offline_runtime.py) into a structured `Exception`. Core runners (`run_source` and `run_source_with_reconnect`) now strictly catch producer/consumer failures (including inner `engine.process_frame` exceptions) and cleanly surface them as rich `RuntimeFailureState` errors.
- **Resource Cleanup:** Resolved a dangling resource leak in [`produce_frames_from_source`](https://github.com/lukaszjecek/human-behavior-recognition-in-video-streams/blob/74-feature-handle-stream-interruption-and-graceful-reconnect-in-runtime/src/inference/offline_runtime.py) by ensuring `cap.release()` executes even if the adapter opens but `isOpened()` evaluates to `False`. 
- **API Expositions:** Added `run_source` and `run_video` to [`__init__.py.__all__`](https://github.com/lukaszjecek/human-behavior-recognition-in-video-streams/blob/74-feature-handle-stream-interruption-and-graceful-reconnect-in-runtime/src/inference/__init__.py) exports for direct access. Cleaned up dead stats tracking variables.
- **Reliability Tests:** Rewrote infinite loop test failures in [`test_service.py`](https://github.com/lukaszjecek/human-behavior-recognition-in-video-streams/blob/74-feature-handle-stream-interruption-and-graceful-reconnect-in-runtime/tests/inference/test_service.py) and [`test_runtime_reliability.py`](https://github.com/lukaszjecek/human-behavior-recognition-in-video-streams/blob/74-feature-handle-stream-interruption-and-graceful-reconnect-in-runtime/tests/inference/test_runtime_reliability.py) using explicit thread limits and graceful shutdown triggers. `pytest` now reliably executes the full `177` test suite validating the new reconnection routines securely.

## Linked Issue
Closes #74

## Checklist
- [x] Changes were tested locally
- [x] CI passes
- [ ] ~~README/docs updated if relevant~~ N/A
- [x] Scope matches the linked Issue
- [x] No direct work outside the agreed scope