### PR TITLE
80 feature add rest endpoints for inference session lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ open http://localhost:8000/docs
 open http://localhost:8000/redoc
 ```
 
+### Inference Session REST Endpoints
+
+The API now exposes endpoints for managing offline inference sessions asynchronously:
+- `POST /api/sessions/` - Starts a new inference session in a background thread.
+- `GET /api/sessions/{session_id}` - Retrieves the current status (`pending`, `running`, `completed`, `failed`, `stopped`).
+- `POST /api/sessions/{session_id}/stop` - Gracefully interrupts and stops an ongoing running session.
+
+These endpoints use `asyncio.to_thread` for non-blocking execution and native `threading.Event` triggers down to the underlying inference loops to allow safe and clean interruptions without blocking the FastAPI event loop.
+
 ### Configuration
 
 Backend configuration is managed through environment variables in `src/app/core/settings.py`:

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -113,3 +113,29 @@ python scripts/validate_modules.py
 ```
 
 This script validates all inference modules and updates the sample file at the canonical location: `tests/inference/data/logs/sample_actions.json`
+
+# Inference Session API
+
+The backend provides asynchronous REST endpoints to manage offline video inference sessions without blocking the main event loop.
+
+## Endpoints
+
+- `POST /api/sessions/`
+  - Starts a new inference session in the background.
+  - Requires a JSON body with `video_path`, `checkpoint_path`, and `config_path`.
+  - Returns HTTP 201 Created with the session ID. Returns HTTP 409 Conflict if the same video is already being processed.
+  
+- `GET /api/sessions/{session_id}`
+  - Retrieves the current status of the session.
+  - Returns the session metadata including status (`pending`, `running`, `completed`, `failed`, `stopped`).
+
+- `POST /api/sessions/{session_id}/stop`
+  - Safely interrupts an ongoing inference session using a native `threading.Event`.
+  - Returns HTTP 202 Accepted if the session is stopped successfully.
+  - Returns HTTP 400 Bad Request if the session is already finished.
+
+## Architecture
+
+- **Session Manager:** (`src/app/services/session_manager.py`) Manages state and `asyncio.Task` references in-memory.
+- **Background Execution:** Inference is pushed to a background thread using `asyncio.to_thread()` so the FastAPI server remains fully responsive.
+- **Graceful Shutdown:** Stopping a session injects a `threading.Event` signal deep into the offline frame producer loop (`src/inference/offline_runtime.py`), causing the video reading loop to break cleanly on the next frame.

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -41,8 +41,8 @@ If neither is provided, `src.main` runs startup summary mode.
 
 ## Reusable service entrypoint
 
-For programmatic integrations (for example upcoming backend routes), use the
-service API instead of the CLI wrapper:
+For programmatic integrations (for example the session management endpoints in `src/app/endpoints/sessions.py`), use the
+service API instead of the CLI wrapper. The service accepts an optional `stop_event` (`threading.Event`) to allow graceful interruptions:
 
 ```python
 from pathlib import Path

--- a/src/app/api/routes_impl.py
+++ b/src/app/api/routes_impl.py
@@ -11,4 +11,4 @@ async def api_root() -> dict[str, object]:
     """Placeholder for the API root endpoint."""
     return {"message": "API root"}
 
-router.include_router(sessions_router, tags=["sessions"])
+router.include_router(sessions_router, prefix="/sessions", tags=["sessions"])

--- a/src/app/api/routes_impl.py
+++ b/src/app/api/routes_impl.py
@@ -1,10 +1,8 @@
 """Implementation of API routes."""
-from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter
 
-from src.app.schemas.session import SessionResponse, SessionStartRequest, SessionStatus
-from src.app.services.session_manager import manager
+from src.app.endpoints.sessions import router as sessions_router
 
 router = APIRouter()
 
@@ -13,58 +11,4 @@ async def api_root() -> dict[str, object]:
     """Placeholder for the API root endpoint."""
     return {"message": "API root"}
 
-
-@router.post(
-    "/sessions",
-    response_model=SessionResponse,
-    status_code=status.HTTP_201_CREATED,
-    summary="Start Inference Session",
-)
-async def start_session(request: SessionStartRequest) -> SessionResponse:
-    """Start a new asynchronous offline inference session."""
-    return manager.create_session(request)
-
-
-@router.get(
-    "/sessions/{session_id}",
-    response_model=SessionResponse,
-    summary="Get Session Status",
-)
-async def get_session(session_id: UUID) -> SessionResponse:
-    """Retrieve the current status and metadata of an inference session."""
-    session = manager.get_session(session_id)
-    if not session:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Session not found"
-        )
-    return session
-
-
-@router.post(
-    "/sessions/{session_id}/stop",
-    response_model=SessionResponse,
-    summary="Stop Inference Session",
-)
-async def stop_session(session_id: UUID) -> SessionResponse:
-    """Stop an ongoing inference session."""
-    session = manager.get_session(session_id)
-    if not session:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Session not found"
-        )
-
-    if session.status not in (SessionStatus.PENDING, SessionStatus.RUNNING):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Cannot stop a session that is not running"
-        )
-
-    # Calling stop_session on the manager will gracefully set the stop_event
-    stopped_session = manager.stop_session(session_id)
-    # The manager could return None theoretically if it vanished, but we know it exists
-    if not stopped_session:
-         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
-    
-    return stopped_session
+router.include_router(sessions_router, tags=["sessions"])

--- a/src/app/api/routes_impl.py
+++ b/src/app/api/routes_impl.py
@@ -1,5 +1,10 @@
 """Implementation of API routes."""
-from fastapi import APIRouter
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, status
+
+from src.app.schemas.session import SessionResponse, SessionStartRequest, SessionStatus
+from src.app.services.session_manager import manager
 
 router = APIRouter()
 
@@ -7,3 +12,59 @@ router = APIRouter()
 async def api_root() -> dict[str, object]:
     """Placeholder for the API root endpoint."""
     return {"message": "API root"}
+
+
+@router.post(
+    "/sessions",
+    response_model=SessionResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Start Inference Session",
+)
+async def start_session(request: SessionStartRequest) -> SessionResponse:
+    """Start a new asynchronous offline inference session."""
+    return manager.create_session(request)
+
+
+@router.get(
+    "/sessions/{session_id}",
+    response_model=SessionResponse,
+    summary="Get Session Status",
+)
+async def get_session(session_id: UUID) -> SessionResponse:
+    """Retrieve the current status and metadata of an inference session."""
+    session = manager.get_session(session_id)
+    if not session:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Session not found"
+        )
+    return session
+
+
+@router.post(
+    "/sessions/{session_id}/stop",
+    response_model=SessionResponse,
+    summary="Stop Inference Session",
+)
+async def stop_session(session_id: UUID) -> SessionResponse:
+    """Stop an ongoing inference session."""
+    session = manager.get_session(session_id)
+    if not session:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Session not found"
+        )
+
+    if session.status not in (SessionStatus.PENDING, SessionStatus.RUNNING):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot stop a session that is not running"
+        )
+
+    # Calling stop_session on the manager will gracefully set the stop_event
+    stopped_session = manager.stop_session(session_id)
+    # The manager could return None theoretically if it vanished, but we know it exists
+    if not stopped_session:
+         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
+    
+    return stopped_session

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -35,7 +35,7 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
     )
 
     app.include_router(health_router)
-    app.include_router(api_router, prefix="/api", tags=["rest"])
+    app.include_router(api_router, prefix="/api")
     app.include_router(ws_router, prefix="/ws", tags=["websocket"])
 
     # Globalna obsługa błędów

--- a/src/app/endpoints/sessions.py
+++ b/src/app/endpoints/sessions.py
@@ -1,0 +1,72 @@
+"""Implementation of session REST endpoints."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, status
+
+from src.app.schemas.session import SessionResponse, SessionStartRequest, SessionStatus
+from src.app.services.session_manager import manager
+
+router = APIRouter()
+
+
+@router.post(
+    "/sessions",
+    response_model=SessionResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Start Inference Session",
+)
+async def start_session(request: SessionStartRequest) -> SessionResponse:
+    """Start a new asynchronous offline inference session."""
+    try:
+        return manager.create_session(request)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc)
+        )
+
+
+@router.get(
+    "/sessions/{session_id}",
+    response_model=SessionResponse,
+    summary="Get Session Status",
+)
+async def get_session(session_id: UUID) -> SessionResponse:
+    """Retrieve the current status and metadata of an inference session."""
+    session = manager.get_session(session_id)
+    if not session:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Session not found"
+        )
+    return session
+
+
+@router.post(
+    "/sessions/{session_id}/stop",
+    response_model=SessionResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Stop Inference Session",
+)
+async def stop_session(session_id: UUID) -> SessionResponse:
+    """Stop an ongoing inference session."""
+    session = manager.get_session(session_id)
+    if not session:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Session not found"
+        )
+
+    if session.status not in (SessionStatus.PENDING, SessionStatus.RUNNING):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot stop a session that is not running"
+        )
+
+    # Calling stop_session on the manager will gracefully set the stop_event
+    stopped_session = manager.stop_session(session_id)
+    if not stopped_session:
+         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
+    
+    return stopped_session

--- a/src/app/endpoints/sessions.py
+++ b/src/app/endpoints/sessions.py
@@ -11,7 +11,7 @@ router = APIRouter()
 
 
 @router.post(
-    "/sessions",
+    "/",
     response_model=SessionResponse,
     status_code=status.HTTP_201_CREATED,
     summary="Start Inference Session",
@@ -28,7 +28,7 @@ async def start_session(request: SessionStartRequest) -> SessionResponse:
 
 
 @router.get(
-    "/sessions/{session_id}",
+    "/{session_id}",
     response_model=SessionResponse,
     summary="Get Session Status",
 )
@@ -44,7 +44,7 @@ async def get_session(session_id: UUID) -> SessionResponse:
 
 
 @router.post(
-    "/sessions/{session_id}/stop",
+    "/{session_id}/stop",
     response_model=SessionResponse,
     status_code=status.HTTP_202_ACCEPTED,
     summary="Stop Inference Session",

--- a/src/app/schemas/session.py
+++ b/src/app/schemas/session.py
@@ -1,0 +1,59 @@
+"""Schemas for inference session REST endpoints."""
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, FilePath
+
+
+class SessionStatus(str, Enum):
+    """Lifecycle states of an inference session."""
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    STOPPED = "stopped"
+
+
+class SessionStartRequest(BaseModel):
+    """Payload for starting a new inference session."""
+
+    video_path: FilePath = Field(
+        ..., description="Absolute path to the input .mp4 video file."
+    )
+    checkpoint_path: FilePath = Field(
+        ..., description="Absolute path to the model checkpoint file."
+    )
+    config_path: FilePath = Field(
+        ..., description="Absolute path to the runtime configuration file (e.g., .yml)."
+    )
+    device: Optional[str] = Field(
+        default=None, description="Hardware device to use (e.g., 'cuda:0', 'cpu')."
+    )
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "video_path": "data/raw/sample.mp4",
+                "checkpoint_path": "data/logs/checkpoints/baseline_epoch_10.pth",
+                "config_path": "configs/data_pipeline.yml",
+                "device": "cpu"
+            }
+        }
+    )
+
+
+class SessionResponse(BaseModel):
+    """Response payload containing session details."""
+
+    id: UUID = Field(..., description="Unique identifier of the session.")
+    status: SessionStatus = Field(..., description="Current status of the session.")
+    created_at: datetime = Field(..., description="When the session was created.")
+    updated_at: datetime = Field(..., description="When the session status was last updated.")
+    error: Optional[str] = Field(
+        default=None, description="Error message if the session failed."
+    )
+
+    model_config = ConfigDict(from_attributes=True)

--- a/src/app/services/session_manager.py
+++ b/src/app/services/session_manager.py
@@ -1,0 +1,107 @@
+"""Service layer for managing inference sessions."""
+
+import asyncio
+from datetime import datetime, timezone
+from threading import Event
+from uuid import UUID, uuid4
+
+from src.app.schemas.session import SessionResponse, SessionStartRequest, SessionStatus
+from src.inference.service import InferenceServiceRequest, run_offline_mp4_inference
+
+
+class SessionData:
+    """Internal model for tracking a session."""
+
+    def __init__(self, request: SessionStartRequest):
+        self.id = uuid4()
+        self.status = SessionStatus.PENDING
+        self.created_at = datetime.now(timezone.utc)
+        self.updated_at = self.created_at
+        self.error: str | None = None
+        self.request = request
+        self.stop_event = Event()
+        self.task: asyncio.Task | None = None
+
+    def update_status(self, status: SessionStatus, error: str | None = None) -> None:
+        """Update session status and timestamp."""
+        self.status = status
+        self.updated_at = datetime.now(timezone.utc)
+        if error is not None:
+            self.error = error
+
+    def to_response(self) -> SessionResponse:
+        """Convert to external response schema."""
+        return SessionResponse(
+            id=self.id,
+            status=self.status,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+            error=self.error,
+        )
+
+
+class InferenceSessionManager:
+    """Manages lifecycle of inference sessions."""
+
+    def __init__(self) -> None:
+        self._sessions: dict[UUID, SessionData] = {}
+
+    def create_session(self, request: SessionStartRequest) -> SessionResponse:
+        """Create and start a new inference session."""
+        session = SessionData(request)
+        self._sessions[session.id] = session
+
+        session.update_status(SessionStatus.RUNNING)
+        session.task = asyncio.create_task(self._run_session_task(session))
+
+        return session.to_response()
+
+    def get_session(self, session_id: UUID) -> SessionResponse | None:
+        """Retrieve a session by its ID."""
+        session = self._sessions.get(session_id)
+        return session.to_response() if session else None
+
+    def stop_session(self, session_id: UUID) -> SessionResponse | None:
+        """Attempt to stop a running session."""
+        session = self._sessions.get(session_id)
+        if not session:
+            return None
+
+        if session.status in (SessionStatus.PENDING, SessionStatus.RUNNING):
+            session.stop_event.set()
+            session.update_status(SessionStatus.STOPPED)
+            # The running task will naturally exit on the next frame due to stop_event
+            # being checked inside the inference loop.
+        
+        return session.to_response()
+
+    async def _run_session_task(self, session: SessionData) -> None:
+        """Background task that runs the blocking inference."""
+        try:
+            # Map API request to internal request
+            inference_request = InferenceServiceRequest(
+                video_path=session.request.video_path,
+                checkpoint_path=session.request.checkpoint_path,
+                config_path=session.request.config_path,
+                device=session.request.device,
+            )
+
+            # Run blocking call in a background thread
+            await asyncio.to_thread(
+                run_offline_mp4_inference,
+                inference_request,
+                session.stop_event,
+            )
+
+            # Only update to COMPLETED if not stopped manually
+            if session.status == SessionStatus.RUNNING:
+                session.update_status(SessionStatus.COMPLETED)
+
+        except Exception as exc:
+            # If the session wasn't explicitly stopped, mark as FAILED
+            if session.status != SessionStatus.STOPPED:
+                session.update_status(SessionStatus.FAILED, str(exc))
+
+
+# Global instance to be used by endpoints
+manager = InferenceSessionManager()

--- a/src/app/services/session_manager.py
+++ b/src/app/services/session_manager.py
@@ -12,7 +12,8 @@ from src.inference.service import InferenceServiceRequest, run_offline_mp4_infer
 class SessionData:
     """Internal model for tracking a session."""
 
-    def __init__(self, request: SessionStartRequest):
+    def __init__(self, request: SessionStartRequest) -> None:
+        """Initialize session data with the original request."""
         self.id = uuid4()
         self.status = SessionStatus.PENDING
         self.created_at = datetime.now(timezone.utc)
@@ -44,6 +45,7 @@ class InferenceSessionManager:
     """Manages lifecycle of inference sessions."""
 
     def __init__(self) -> None:
+        """Initialize the inference session manager."""
         self._sessions: dict[UUID, SessionData] = {}
 
     def create_session(self, request: SessionStartRequest) -> SessionResponse:
@@ -52,7 +54,10 @@ class InferenceSessionManager:
         for existing_session in self._sessions.values():
             if existing_session.status in (SessionStatus.PENDING, SessionStatus.RUNNING):
                 if existing_session.request.video_path == request.video_path:
-                    raise ValueError(f"Video {request.video_path} is already being processed in session {existing_session.id}")
+                    raise ValueError(
+                        f"Video {request.video_path} is already being "
+                        f"processed in session {existing_session.id}"
+                    )
 
         session = SessionData(request)
         self._sessions[session.id] = session

--- a/src/app/services/session_manager.py
+++ b/src/app/services/session_manager.py
@@ -48,6 +48,12 @@ class InferenceSessionManager:
 
     def create_session(self, request: SessionStartRequest) -> SessionResponse:
         """Create and start a new inference session."""
+        # Check for duplicates
+        for existing_session in self._sessions.values():
+            if existing_session.status in (SessionStatus.PENDING, SessionStatus.RUNNING):
+                if existing_session.request.video_path == request.video_path:
+                    raise ValueError(f"Video {request.video_path} is already being processed in session {existing_session.id}")
+
         session = SessionData(request)
         self._sessions[session.id] = session
 

--- a/src/inference/offline_runtime.py
+++ b/src/inference/offline_runtime.py
@@ -1,7 +1,7 @@
 """Offline producer-consumer runtime for adapter-based inference inputs."""
 from pathlib import Path
 from queue import Queue
-from threading import Thread
+from threading import Event, Thread
 from typing import Any, Optional
 
 from src.inference.engine import InferenceEngine
@@ -15,6 +15,7 @@ EOF_SENTINEL = object()
 def produce_frames_from_source(
     source_adapter: InferenceSourceAdapter,
     frame_queue: Queue,
+    stop_event: Optional[Event] = None,
 ) -> None:
     """Reads frames from a source adapter in source order and pushes them to a queue.
 
@@ -36,6 +37,8 @@ def produce_frames_from_source(
 
         try:
             while True:
+                if stop_event is not None and stop_event.is_set():
+                    break
                 ret, frame = cap.read()
 
                 if not ret:
@@ -48,23 +51,24 @@ def produce_frames_from_source(
         frame_queue.put(EOF_SENTINEL)
 
 
-def produce_frames(video_path: str, frame_queue: Queue) -> None:
+def produce_frames(video_path: str, frame_queue: Queue, stop_event: Optional[Event] = None) -> None:
     """Backward-compatible file-source producer."""
     if not isinstance(video_path, str):
         raise TypeError("video_path must be a string")
 
     source_adapter = FileSourceAdapter(video_path=Path(video_path))
-    produce_frames_from_source(source_adapter, frame_queue)
+    produce_frames_from_source(source_adapter, frame_queue, stop_event)
 
 
 def produce_frames_safe(
     source_adapter: InferenceSourceAdapter,
     frame_queue: Queue,
     stats: dict,
+    stop_event: Optional[Event] = None,
 ) -> None:
     """Runs the frame producer and stores any raised exception in stats."""
     try:
-        produce_frames_from_source(source_adapter, frame_queue)
+        produce_frames_from_source(source_adapter, frame_queue, stop_event)
     except Exception as exc:
         stats["producer_error"] = exc
 
@@ -102,6 +106,7 @@ def run_source(
     engine: Optional[InferenceEngine] = None,
     tracker: Optional[BaseTracker] = None,
     emit_runtime_summary: bool = True,
+    stop_event: Optional[Event] = None,
 ) -> tuple[int, int, list[Any], list[Any]]:
     """Runs offline inference on a generic source adapter.
 
@@ -135,7 +140,7 @@ def run_source(
     }
 
     producer = Thread(target=produce_frames_safe,
-                      args=(source_adapter, frame_queue, stats))
+                      args=(source_adapter, frame_queue, stats, stop_event))
     consumer = Thread(target=consume_frame_queue,
                       args=(frame_queue, runtime_engine, stats))
 
@@ -172,6 +177,7 @@ def run_video(
     engine: Optional[InferenceEngine] = None,
     tracker: Optional[BaseTracker] = None,
     emit_runtime_summary: bool = True,
+    stop_event: Optional[Event] = None,
 ) -> tuple[int, int, list[Any], list[Any]]:
     """Runs offline inference on a single local video file."""
     if not isinstance(video_path, str):
@@ -183,4 +189,5 @@ def run_video(
         engine=engine,
         tracker=tracker,
         emit_runtime_summary=emit_runtime_summary,
+        stop_event=stop_event,
     )

--- a/src/inference/service.py
+++ b/src/inference/service.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
+from threading import Event
 
 import torch
 
@@ -55,7 +56,10 @@ class InferenceServiceResult:
         return len(self.action_events)
 
 
-def run_inference(request: InferenceServiceRequest) -> InferenceServiceResult:
+def run_inference(
+    request: InferenceServiceRequest,
+    stop_event: Event | None = None,
+) -> InferenceServiceResult:
     """Run inference and return typed in-memory results."""
     if not isinstance(request, InferenceServiceRequest):
         raise TypeError("request must be an InferenceServiceRequest instance")
@@ -86,6 +90,7 @@ def run_inference(request: InferenceServiceRequest) -> InferenceServiceResult:
         source_adapter=source_adapter,
         engine=engine,
         emit_runtime_summary=False,
+        stop_event=stop_event,
     )
     expanded_results = expand_batched_inference_results(inference_results)
     track_ids = build_track_ids(expanded_results, settings.default_track_id)
@@ -103,12 +108,15 @@ def run_inference(request: InferenceServiceRequest) -> InferenceServiceResult:
     )
 
 
-def run_offline_mp4_inference(request: InferenceServiceRequest) -> InferenceServiceResult:
+def run_offline_mp4_inference(
+    request: InferenceServiceRequest,
+    stop_event: Event | None = None,
+) -> InferenceServiceResult:
     """Run offline inference for local MP4 files only."""
     if not isinstance(request, InferenceServiceRequest):
         raise TypeError("request must be an InferenceServiceRequest instance")
     _validate_offline_mp4_request(request)
-    return run_inference(request)
+    return run_inference(request, stop_event=stop_event)
 
 
 def _validate_offline_mp4_request(request: InferenceServiceRequest) -> None:

--- a/tests/app/test_sessions.py
+++ b/tests/app/test_sessions.py
@@ -1,0 +1,147 @@
+"""Tests for the session lifecycle REST endpoints."""
+
+import threading
+import uuid
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.app.app import create_app
+from src.app.schemas.session import SessionStatus
+
+
+@pytest.fixture
+def client():
+    """Provides a TestClient with the configured FastAPI app."""
+    app = create_app()
+    return TestClient(app)
+
+
+@patch("src.app.services.session_manager.run_offline_mp4_inference")
+def test_session_happy_path(mock_inference, client, tmp_path):
+    """Test full lifecycle: start -> status -> stop, mocking the actual inference."""
+    pause_event = threading.Event()
+    def mock_run(*args, **kwargs):
+        pause_event.wait(timeout=2.0)
+    mock_inference.side_effect = mock_run
+    
+    # Setup dummy files for FilePath validation
+    video_file = tmp_path / "video.mp4"
+    video_file.touch()
+    ckpt_file = tmp_path / "model.pth"
+    ckpt_file.touch()
+    config_file = tmp_path / "config.yml"
+    config_file.touch()
+
+    # 1. Start session
+    payload = {
+        "video_path": str(video_file),
+        "checkpoint_path": str(ckpt_file),
+        "config_path": str(config_file),
+    }
+    
+    response = client.post("/api/sessions", json=payload)
+    assert response.status_code == 201
+    data = response.json()
+    assert "id" in data
+    assert data["status"] == SessionStatus.RUNNING
+    
+    session_id = data["id"]
+    
+    # 2. Get status
+    response = client.get(f"/api/sessions/{session_id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == session_id
+    assert data["status"] == SessionStatus.RUNNING
+
+    # 3. Stop session
+    response = client.post(f"/api/sessions/{session_id}/stop")
+    assert response.status_code == 202
+    data = response.json()
+    assert data["status"] == SessionStatus.STOPPED
+    
+    pause_event.set()
+
+
+@patch("src.app.services.session_manager.run_offline_mp4_inference")
+def test_session_duplicate_video(mock_inference, client, tmp_path):
+    """Test starting a session for a video already being processed yields 409."""
+    pause_event = threading.Event()
+    def mock_run(*args, **kwargs):
+        pause_event.wait(timeout=2.0)
+    mock_inference.side_effect = mock_run
+    
+    video_file = tmp_path / "dup_video.mp4"
+    video_file.touch()
+    ckpt_file = tmp_path / "model.pth"
+    ckpt_file.touch()
+    config_file = tmp_path / "config.yml"
+    config_file.touch()
+
+    payload = {
+        "video_path": str(video_file),
+        "checkpoint_path": str(ckpt_file),
+        "config_path": str(config_file),
+    }
+
+    # First start succeeds
+    resp1 = client.post("/api/sessions", json=payload)
+    assert resp1.status_code == 201
+
+    # Second start with same video fails
+    resp2 = client.post("/api/sessions", json=payload)
+    assert resp2.status_code == 409
+    assert "already being processed" in resp2.json()["detail"]
+    
+    pause_event.set()
+
+
+def test_session_not_found(client):
+    """Test accessing a non-existent session yields 404."""
+    fake_id = str(uuid.uuid4())
+    
+    response = client.get(f"/api/sessions/{fake_id}")
+    assert response.status_code == 404
+    
+    response = client.post(f"/api/sessions/{fake_id}/stop")
+    assert response.status_code == 404
+
+
+@patch("src.app.services.session_manager.run_offline_mp4_inference")
+def test_stop_invalid_state(mock_inference, client, tmp_path):
+    """Test stopping a session that is no longer running yields 400."""
+    pause_event = threading.Event()
+    def mock_run(*args, **kwargs):
+        pause_event.wait(timeout=2.0)
+    mock_inference.side_effect = mock_run
+
+    # Setup dummy files
+    video_file = tmp_path / "video.mp4"
+    video_file.touch()
+    ckpt_file = tmp_path / "model.pth"
+    ckpt_file.touch()
+    config_file = tmp_path / "config.yml"
+    config_file.touch()
+
+    # 1. Start session
+    payload = {
+        "video_path": str(video_file),
+        "checkpoint_path": str(ckpt_file),
+        "config_path": str(config_file),
+    }
+    
+    response = client.post("/api/sessions", json=payload)
+    session_id = response.json()["id"]
+
+    # Stop it once
+    response1 = client.post(f"/api/sessions/{session_id}/stop")
+    assert response1.status_code == 202
+    
+    # Try stopping again
+    response2 = client.post(f"/api/sessions/{session_id}/stop")
+    assert response2.status_code == 400
+    assert "Cannot stop" in response2.json()["detail"]
+    
+    pause_event.set()


### PR DESCRIPTION
Closes #80 

### Goal

Expose REST endpoints that let the system start, stop, and inspect inference sessions through the backend instead of direct script execution.

### Scope

In scope:
- add endpoints for session start, stop, and status
- connect endpoint handlers to the reusable inference service hooks
- define minimal request and response models
- handle basic invalid-state and runtime error cases cleanly
- add local tests for the happy path and one or more error paths

### Implementation Details

1. **Explicit Request/Response Models (Pydantic v2):**
   - Created `src/app/schemas/session.py`.
   - Implemented strong type validation using `FilePath` to catch missing videos, configs, or checkpoints at the API boundary (returning `422 Unprocessable Entity` immediately).
   - Used native `UUID` for session tracking and strict `str`-based `Enum` for `SessionStatus`.

2. **Asynchronous Session Manager & Service Integration:**
   - Implemented `InferenceSessionManager` in `src/app/services/session_manager.py`.
   - Isolated the heavy, blocking inference loop (`run_offline_mp4_inference`) into a background worker thread using `asyncio.to_thread()`, wrapped inside an `asyncio.create_task()`. This prevents the FastAPI event loop from freezing.
   - Integrated a cooperative cancelation token using `threading.Event` deep into the video decoding loop (`offline_runtime.py`) to allow graceful stopping on a frame-by-frame basis.

3. **REST Endpoints & HTTP Semantics:**
   - `POST /api/sessions/` – Starts a session. Returns `201 Created` on success. Includes protection against server overload (returns `409 Conflict` if the same video is already being processed).
   - `GET /api/sessions/{session_id}` – Inspects and returns metadata, timestamps, and errors.
   - `POST /api/sessions/{session_id}/stop` – Triggers the stop event. Returns `202 Accepted` to properly reflect the asynchronous nature of the teardown process. Prevents double-stopping via state checks (`400 Bad Request`).

### Testing Covered
- **Happy Path:** Full lifecycle test (Start -> Inspect running state -> Stop -> Assert `202 Accepted`).
- **Error/Edge Cases:** - Requesting status for a non-existent UUID (`404 Not Found`).
  - Attempting to start a session for a video file that is already actively running (`409 Conflict`).
  - Attempting to stop an already completed or failed session (`400 Bad Request`).
  - 
### Definition of done
- [x] REST endpoints for session lifecycle implemented
- [x] Endpoints call the service layer instead of shell commands
- [x] Request/response models are explicit
- [x] Local tests cover basic session control behavior
- [x] PR created and linked to this issue