### PR TITLE
75 feature implement per track alert state machine

### DIFF
--- a/src/inference/alert_state_machine.py
+++ b/src/inference/alert_state_machine.py
@@ -1,0 +1,35 @@
+"""Per-track alert state machine for behavior detection pipelines.
+
+Transitions action events through INACTIVE → CANDIDATE → ACTIVE → RESOLVED
+states with configurable persistence and resolve thresholds.
+"""
+
+import logging
+from dataclasses import dataclass
+from enum import Enum, auto
+
+logger = logging.getLogger(__name__)
+
+
+class AlertState(Enum):
+    """States of the per-track alert state machine."""
+
+    INACTIVE = auto()
+    CANDIDATE = auto()
+    ACTIVE = auto()
+    RESOLVED = auto()
+
+
+@dataclass
+class TrackAlertRecord:
+    """Mutable alert state record for a single track.
+
+    Attributes:
+        state: Current alert state for this track.
+        consecutive_hits: Number of consecutive danger events since last reset.
+        consecutive_misses: Number of consecutive non-danger events since last hit.
+    """
+
+    state: AlertState = AlertState.INACTIVE
+    consecutive_hits: int = 0
+    consecutive_misses: int = 0

--- a/src/inference/alert_state_machine.py
+++ b/src/inference/alert_state_machine.py
@@ -7,6 +7,9 @@ states with configurable persistence and resolve thresholds.
 import logging
 from dataclasses import dataclass
 from enum import Enum, auto
+from typing import Optional
+
+from src.inference.action_event import ActionEvent
 
 logger = logging.getLogger(__name__)
 
@@ -33,3 +36,327 @@ class TrackAlertRecord:
     state: AlertState = AlertState.INACTIVE
     consecutive_hits: int = 0
     consecutive_misses: int = 0
+
+@dataclass(frozen=True)
+class AlertRaisedEvent:
+    """Emitted when a track transitions to ACTIVE state.
+
+    Attributes:
+        track_id: Track identifier that triggered the alert.
+        label: Danger label from the triggering event.
+        state: Alert state at emission time (always ACTIVE).
+        consecutive_hits: Number of consecutive danger events that triggered activation.
+        triggering_event: The ActionEvent that caused the transition to ACTIVE.
+    """
+
+    track_id: Optional[int]
+    label: str
+    state: AlertState
+    consecutive_hits: int
+    triggering_event: ActionEvent
+
+
+class AlertStateMachine:
+    """Per-track alert state machine for detecting persistent dangerous behaviors.
+
+    Each track_id evolves independently through:
+        INACTIVE → CANDIDATE → ACTIVE → RESOLVED → INACTIVE
+
+    The machine is deterministic: identical event sequences always produce
+    identical state transitions and outputs.
+
+    Example:
+        >>> sm = AlertStateMachine(persistence_threshold=2, danger_labels=["fighting"])
+        >>> event = ActionEvent(0, 1, "fighting", 0.9, track_id=1)
+        >>> sm.process_event(event)  # first hit → CANDIDATE
+        >>> sm.process_event(event)  # second hit → ACTIVE, returns AlertRaisedEvent
+    """
+
+    def __init__(
+        self,
+        persistence_threshold: int = 3,
+        danger_labels: Optional[list[str]] = None,
+        resolve_threshold: int = 1,
+    ) -> None:
+        """Initialize the state machine with threshold parameters.
+
+        Args:
+            persistence_threshold: Number of consecutive danger events required
+                to transition from INACTIVE/CANDIDATE to ACTIVE. Must be >= 1.
+            danger_labels: Labels considered dangerous. None or empty list means
+                every label is treated as danger (miss is never triggered).
+            resolve_threshold: Number of consecutive non-danger events required
+                to transition from ACTIVE to RESOLVED. Must be >= 1.
+
+        Raises:
+            TypeError: If threshold arguments are not integers.
+            ValueError: If threshold arguments are less than 1.
+        """
+        if not isinstance(persistence_threshold, int) or isinstance(
+            persistence_threshold, bool
+        ):
+            raise TypeError("persistence_threshold must be an integer")
+        if persistence_threshold < 1:
+            raise ValueError("persistence_threshold must be >= 1")
+
+        if danger_labels is not None:
+            if not isinstance(danger_labels, list):
+                raise TypeError("danger_labels must be a list of strings or None")
+            for label in danger_labels:
+                if not isinstance(label, str):
+                    raise TypeError("danger_labels must contain only strings")
+                if not label.strip():
+                    raise ValueError("danger_labels must not contain empty strings")
+
+        if not isinstance(resolve_threshold, int) or isinstance(resolve_threshold, bool):
+            raise TypeError("resolve_threshold must be an integer")
+        if resolve_threshold < 1:
+            raise ValueError("resolve_threshold must be >= 1")
+
+        self._persistence_threshold = persistence_threshold
+        self._danger_labels: Optional[list[str]] = danger_labels
+        self._resolve_threshold = resolve_threshold
+        self._tracks: dict[Optional[int], TrackAlertRecord] = {}
+
+    def process_event(self, event: ActionEvent) -> Optional[AlertRaisedEvent]:
+        """Process a single action event and update the corresponding track state.
+
+        Args:
+            event: ActionEvent to process. The track_id field identifies which
+                track record to update.
+
+        Returns:
+            AlertRaisedEvent when a track transitions to ACTIVE, None otherwise.
+
+        Raises:
+            TypeError: If event is not an ActionEvent instance.
+        """
+        if not isinstance(event, ActionEvent):
+            raise TypeError("event must be an ActionEvent instance")
+
+        track_id = event.track_id
+        if track_id not in self._tracks:
+            self._tracks[track_id] = TrackAlertRecord()
+
+        record = self._tracks[track_id]
+        return self._apply_transition(record, event)
+
+    def process_events(self, events: list[ActionEvent]) -> list[AlertRaisedEvent]:
+        """Process a batch of action events and collect all raised alerts.
+
+        Args:
+            events: Ordered list of ActionEvent objects to process.
+
+        Returns:
+            List of AlertRaisedEvent objects emitted during processing,
+            in the order they were triggered.
+
+        Raises:
+            TypeError: If events is not a list.
+        """
+        if not isinstance(events, list):
+            raise TypeError("events must be a list of ActionEvent objects")
+
+        raised: list[AlertRaisedEvent] = []
+        for event in events:
+            result = self.process_event(event)
+            if result is not None:
+                raised.append(result)
+        return raised
+
+    def get_state(self, track_id: Optional[int] = None) -> AlertState:
+        """Return the current alert state for a track.
+
+        Args:
+            track_id: Track identifier to query. Defaults to None.
+
+        Returns:
+            Current AlertState for the track, INACTIVE if never seen.
+        """
+        record = self._tracks.get(track_id)
+        return record.state if record is not None else AlertState.INACTIVE
+
+    def get_record(self, track_id: Optional[int] = None) -> Optional[TrackAlertRecord]:
+        """Return the full alert record for a track.
+
+        Args:
+            track_id: Track identifier to query. Defaults to None.
+
+        Returns:
+            TrackAlertRecord if the track has been seen, None otherwise.
+        """
+        return self._tracks.get(track_id)
+
+    def active_track_ids(self) -> list[Optional[int]]:
+        """Return track IDs whose current state is ACTIVE.
+
+        Returns:
+            List of track_id values (may include None) in ACTIVE state.
+        """
+        return [
+            tid
+            for tid, record in self._tracks.items()
+            if record.state == AlertState.ACTIVE
+        ]
+
+    def reset_all(self) -> None:
+        """Reset all track records, returning every track to INACTIVE.
+
+        Clears all accumulated hit/miss counts and removes all track entries.
+        """
+        self._tracks.clear()
+        logger.debug("AlertStateMachine: all tracks reset to INACTIVE")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _is_danger(self, label: str) -> bool:
+        """Return True when label counts as a danger event.
+
+        Args:
+            label: Action label from an ActionEvent.
+
+        Returns:
+            True if the label is considered dangerous given current config.
+        """
+        if not self._danger_labels:
+            return True
+        return label in self._danger_labels
+
+    def _apply_transition(
+        self,
+        record: TrackAlertRecord,
+        event: ActionEvent,
+    ) -> Optional[AlertRaisedEvent]:
+        """Apply one state-machine transition and return an alert if raised.
+
+        Args:
+            record: Mutable per-track state record (mutated in place).
+            event: ActionEvent that drives the transition.
+
+        Returns:
+            AlertRaisedEvent if the track just became ACTIVE, None otherwise.
+        """
+        is_danger = self._is_danger(event.label)
+        track_id = event.track_id
+
+        if record.state == AlertState.INACTIVE:
+            if is_danger:
+                record.consecutive_hits = 1
+                record.consecutive_misses = 0
+                if record.consecutive_hits >= self._persistence_threshold:
+                    record.state = AlertState.ACTIVE
+                    logger.info(
+                        "Track %s: INACTIVE → ACTIVE (hits=%d)",
+                        track_id,
+                        record.consecutive_hits,
+                    )
+                    return self._make_alert(record, event)
+                record.state = AlertState.CANDIDATE
+                logger.debug(
+                    "Track %s: INACTIVE → CANDIDATE (hits=%d)",
+                    track_id,
+                    record.consecutive_hits,
+                )
+            # miss in INACTIVE → stay INACTIVE (no log noise)
+
+        elif record.state == AlertState.CANDIDATE:
+            if is_danger:
+                record.consecutive_hits += 1
+                if record.consecutive_hits >= self._persistence_threshold:
+                    record.state = AlertState.ACTIVE
+                    logger.info(
+                        "Track %s: CANDIDATE → ACTIVE (hits=%d)",
+                        track_id,
+                        record.consecutive_hits,
+                    )
+                    return self._make_alert(record, event)
+                logger.debug(
+                    "Track %s: CANDIDATE stays CANDIDATE (hits=%d)",
+                    track_id,
+                    record.consecutive_hits,
+                )
+            else:
+                record.state = AlertState.INACTIVE
+                record.consecutive_hits = 0
+                record.consecutive_misses = 0
+                logger.debug("Track %s: CANDIDATE → INACTIVE (miss)", track_id)
+
+        elif record.state == AlertState.ACTIVE:
+            if is_danger:
+                record.consecutive_misses = 0
+                logger.debug("Track %s: ACTIVE stays ACTIVE (danger)", track_id)
+            else:
+                record.consecutive_misses += 1
+                if record.consecutive_misses >= self._resolve_threshold:
+                    record.state = AlertState.RESOLVED
+                    record.consecutive_hits = 0
+                    logger.debug(
+                        "Track %s: ACTIVE → RESOLVED (misses=%d)",
+                        track_id,
+                        record.consecutive_misses,
+                    )
+                else:
+                    logger.debug(
+                        "Track %s: ACTIVE stays ACTIVE (misses=%d, resolve_threshold=%d)",
+                        track_id,
+                        record.consecutive_misses,
+                        self._resolve_threshold,
+                    )
+
+        elif record.state == AlertState.RESOLVED:
+            if is_danger:
+                record.consecutive_hits = 1
+                record.consecutive_misses = 0
+                if record.consecutive_hits >= self._persistence_threshold:
+                    record.state = AlertState.ACTIVE
+                    logger.info(
+                        "Track %s: RESOLVED → ACTIVE (hits=%d)",
+                        track_id,
+                        record.consecutive_hits,
+                    )
+                    return self._make_alert(record, event)
+                record.state = AlertState.CANDIDATE
+                logger.debug(
+                    "Track %s: RESOLVED → CANDIDATE (hits=%d)",
+                    track_id,
+                    record.consecutive_hits,
+                )
+            else:
+                record.state = AlertState.INACTIVE
+                record.consecutive_hits = 0
+                record.consecutive_misses = 0
+                logger.debug("Track %s: RESOLVED → INACTIVE (miss)", track_id)
+
+        return None
+
+    @staticmethod
+    def _make_alert(
+        record: TrackAlertRecord,
+        event: ActionEvent,
+    ) -> AlertRaisedEvent:
+        """Construct an AlertRaisedEvent from the current record and event.
+
+        Args:
+            record: Current track alert record (state must already be ACTIVE).
+            event: ActionEvent that triggered the transition.
+
+        Returns:
+            Populated AlertRaisedEvent.
+        """
+        return AlertRaisedEvent(
+            track_id=event.track_id,
+            label=event.label,
+            state=AlertState.ACTIVE,
+            consecutive_hits=record.consecutive_hits,
+            triggering_event=event,
+        )
+
+
+__all__ = [
+    "AlertRaisedEvent",
+    "AlertState",
+    "AlertStateMachine",
+    "TrackAlertRecord",
+]

--- a/tests/inference/test_alert_state_machine.py
+++ b/tests/inference/test_alert_state_machine.py
@@ -1,0 +1,301 @@
+from typing import Optional
+
+import pytest
+
+from src.inference.action_event import ActionEvent
+from src.inference.alert_state_machine import (
+    AlertRaisedEvent,
+    AlertState,
+    AlertStateMachine,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _evt(label: str, track_id: Optional[int] = None) -> ActionEvent:
+    return ActionEvent(
+        start_frame_index=0,
+        end_frame_index=1,
+        label=label,
+        confidence=0.9,
+        track_id=track_id,
+    )
+
+
+def _danger_sm(threshold: int = 3, resolve: int = 1) -> AlertStateMachine:
+    return AlertStateMachine(
+        persistence_threshold=threshold,
+        danger_labels=["fight"],
+        resolve_threshold=resolve,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Basic state transitions
+# ---------------------------------------------------------------------------
+
+
+def test_inactive_to_candidate_on_first_danger():
+    sm = _danger_sm(threshold=3)
+    result = sm.process_event(_evt("fight"))
+    assert result is None
+    assert sm.get_state() == AlertState.CANDIDATE
+
+
+def test_candidate_to_inactive_on_miss():
+    sm = _danger_sm(threshold=3)
+    sm.process_event(_evt("fight"))
+    sm.process_event(_evt("walk"))
+    assert sm.get_state() == AlertState.INACTIVE
+
+
+def test_candidate_to_active_at_threshold():
+    sm = _danger_sm(threshold=3)
+    results = [sm.process_event(_evt("fight")) for _ in range(3)]
+    assert results[0] is None
+    assert results[1] is None
+    alert = results[2]
+    assert isinstance(alert, AlertRaisedEvent)
+    assert alert.state == AlertState.ACTIVE
+    assert alert.consecutive_hits == 3
+    assert sm.get_state() == AlertState.ACTIVE
+
+
+def test_active_stays_active_on_continued_danger():
+    sm = _danger_sm(threshold=2)
+    sm.process_event(_evt("fight"))
+    sm.process_event(_evt("fight"))  # → ACTIVE
+    result = sm.process_event(_evt("fight"))
+    assert result is None
+    assert sm.get_state() == AlertState.ACTIVE
+
+
+def test_active_to_resolved_after_resolve_threshold():
+    sm = _danger_sm(threshold=2, resolve=2)
+    sm.process_event(_evt("fight"))
+    sm.process_event(_evt("fight"))  # → ACTIVE
+    sm.process_event(_evt("walk"))   # misses=1, resolve=2 → still ACTIVE
+    assert sm.get_state() == AlertState.ACTIVE
+    sm.process_event(_evt("walk"))   # misses=2 >= 2 → RESOLVED
+    assert sm.get_state() == AlertState.RESOLVED
+
+
+def test_resolved_to_candidate_on_new_danger():
+    sm = _danger_sm(threshold=2, resolve=1)
+    sm.process_event(_evt("fight"))
+    sm.process_event(_evt("fight"))  # → ACTIVE
+    sm.process_event(_evt("walk"))   # → RESOLVED
+    sm.process_event(_evt("fight"))  # → CANDIDATE (threshold=2 needs another hit)
+    assert sm.get_state() == AlertState.CANDIDATE
+
+
+def test_resolved_to_inactive_on_miss():
+    sm = _danger_sm(threshold=2, resolve=1)
+    sm.process_event(_evt("fight"))
+    sm.process_event(_evt("fight"))  # → ACTIVE
+    sm.process_event(_evt("walk"))   # → RESOLVED
+    sm.process_event(_evt("walk"))   # → INACTIVE
+    assert sm.get_state() == AlertState.INACTIVE
+
+
+# ---------------------------------------------------------------------------
+# Threshold edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_persistence_threshold_1_goes_directly_to_active():
+    sm = AlertStateMachine(persistence_threshold=1, danger_labels=["fight"])
+    alert = sm.process_event(_evt("fight"))
+    assert isinstance(alert, AlertRaisedEvent)
+    assert sm.get_state() == AlertState.ACTIVE
+
+
+def test_resolve_threshold_1_resolves_on_single_miss():
+    sm = _danger_sm(threshold=1, resolve=1)
+    sm.process_event(_evt("fight"))  # → ACTIVE immediately
+    sm.process_event(_evt("walk"))   # → RESOLVED
+    assert sm.get_state() == AlertState.RESOLVED
+
+
+# ---------------------------------------------------------------------------
+# Per-track isolation
+# ---------------------------------------------------------------------------
+
+
+def test_track_isolation():
+    sm = _danger_sm(threshold=2)
+    # Push track 1 to ACTIVE
+    sm.process_event(_evt("fight", track_id=1))
+    sm.process_event(_evt("fight", track_id=1))
+    # Track 2 receives a miss — must not affect track 1
+    sm.process_event(_evt("walk", track_id=2))
+    assert sm.get_state(track_id=1) == AlertState.ACTIVE
+    assert sm.get_state(track_id=2) == AlertState.INACTIVE
+
+
+def test_none_track_id_handled():
+    sm = _danger_sm(threshold=1)
+    alert = sm.process_event(_evt("fight", track_id=None))
+    assert isinstance(alert, AlertRaisedEvent)
+    assert alert.track_id is None
+    assert sm.get_state(track_id=None) == AlertState.ACTIVE
+
+
+def test_none_track_id_isolated_from_int_track_id():
+    sm = _danger_sm(threshold=2)
+    sm.process_event(_evt("fight", track_id=None))
+    sm.process_event(_evt("fight", track_id=None))  # → ACTIVE for track None
+    # Integer track 0 should be INACTIVE
+    assert sm.get_state(track_id=0) == AlertState.INACTIVE
+    assert sm.get_state(track_id=None) == AlertState.ACTIVE
+
+
+# ---------------------------------------------------------------------------
+# danger_labels filter
+# ---------------------------------------------------------------------------
+
+
+def test_danger_labels_filter_safe_label_is_miss():
+    sm = AlertStateMachine(persistence_threshold=3, danger_labels=["fight", "steal"])
+    sm.process_event(_evt("fight"))   # hit → CANDIDATE
+    sm.process_event(_evt("steal"))   # hit → CANDIDATE (hits=2)
+    sm.process_event(_evt("walk"))    # miss → INACTIVE
+    assert sm.get_state() == AlertState.INACTIVE
+
+
+def test_danger_labels_none_treats_all_labels_as_danger():
+    sm = AlertStateMachine(persistence_threshold=2, danger_labels=None)
+    sm.process_event(_evt("walk"))    # any label is danger → CANDIDATE
+    alert = sm.process_event(_evt("sit"))  # second → ACTIVE
+    assert isinstance(alert, AlertRaisedEvent)
+    assert sm.get_state() == AlertState.ACTIVE
+
+
+def test_danger_labels_empty_list_treats_all_labels_as_danger():
+    sm = AlertStateMachine(persistence_threshold=2, danger_labels=[])
+    sm.process_event(_evt("walk"))
+    alert = sm.process_event(_evt("sit"))
+    assert isinstance(alert, AlertRaisedEvent)
+
+
+# ---------------------------------------------------------------------------
+# Batch processing
+# ---------------------------------------------------------------------------
+
+
+def test_process_events_batch():
+    sm = _danger_sm(threshold=2)
+    events = [_evt("fight"), _evt("fight"), _evt("walk"), _evt("fight")]
+    alerts = sm.process_events(events)
+    # Only the 2nd event triggers an alert
+    assert len(alerts) == 1
+    assert alerts[0].consecutive_hits == 2
+
+
+def test_process_events_returns_empty_when_no_alerts():
+    sm = _danger_sm(threshold=3)
+    alerts = sm.process_events([_evt("fight"), _evt("fight")])
+    assert alerts == []
+
+
+# ---------------------------------------------------------------------------
+# active_track_ids
+# ---------------------------------------------------------------------------
+
+
+def test_active_track_ids_returns_only_active_tracks():
+    sm = _danger_sm(threshold=1)
+    sm.process_event(_evt("fight", track_id=1))   # → ACTIVE
+    sm.process_event(_evt("fight", track_id=2))   # → ACTIVE
+    sm.process_event(_evt("fight", track_id=3))   # → ACTIVE
+    sm.process_event(_evt("walk", track_id=2))    # → RESOLVED (resolve=1)
+    active = sm.active_track_ids()
+    assert set(active) == {1, 3}
+
+
+def test_active_track_ids_empty_when_no_active_tracks():
+    sm = _danger_sm(threshold=3)
+    sm.process_event(_evt("fight", track_id=5))
+    assert sm.active_track_ids() == []
+
+
+# ---------------------------------------------------------------------------
+# reset_all
+# ---------------------------------------------------------------------------
+
+
+def test_reset_all_clears_state():
+    sm = _danger_sm(threshold=1)
+    sm.process_event(_evt("fight", track_id=1))
+    sm.process_event(_evt("fight", track_id=2))
+    assert sm.get_state(track_id=1) == AlertState.ACTIVE
+
+    sm.reset_all()
+
+    assert sm.get_state(track_id=1) == AlertState.INACTIVE
+    assert sm.get_state(track_id=2) == AlertState.INACTIVE
+    assert sm.get_record(track_id=1) is None
+    assert sm.active_track_ids() == []
+
+
+# ---------------------------------------------------------------------------
+# get_record
+# ---------------------------------------------------------------------------
+
+
+def test_get_record_returns_none_for_unseen_track():
+    sm = _danger_sm()
+    assert sm.get_record(track_id=99) is None
+
+
+def test_get_record_reflects_hits_and_state():
+    sm = _danger_sm(threshold=3)
+    sm.process_event(_evt("fight"))
+    sm.process_event(_evt("fight"))
+    record = sm.get_record()
+    assert record is not None
+    assert record.consecutive_hits == 2
+    assert record.state == AlertState.CANDIDATE
+
+
+# ---------------------------------------------------------------------------
+# AlertRaisedEvent content
+# ---------------------------------------------------------------------------
+
+
+def test_alert_raised_event_contains_triggering_event():
+    sm = _danger_sm(threshold=1)
+    ev = _evt("fight", track_id=7)
+    alert = sm.process_event(ev)
+    assert alert is not None
+    assert alert.triggering_event is ev
+    assert alert.label == "fight"
+    assert alert.track_id == 7
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_persistence_threshold_raises():
+    with pytest.raises(ValueError):
+        AlertStateMachine(persistence_threshold=0)
+    with pytest.raises(TypeError):
+        AlertStateMachine(persistence_threshold="3")  # type: ignore[arg-type]
+
+
+def test_invalid_resolve_threshold_raises():
+    with pytest.raises(ValueError):
+        AlertStateMachine(resolve_threshold=0)
+    with pytest.raises(TypeError):
+        AlertStateMachine(resolve_threshold=1.5)  # type: ignore[arg-type]
+
+
+def test_invalid_danger_labels_raises():
+    with pytest.raises(TypeError):
+        AlertStateMachine(danger_labels="fight")  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        AlertStateMachine(danger_labels=[1, 2])  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
Implements a per-track alert state machine for the inference pipeline.
A danger alert is raised only when a target condition persists across a
configurable number of consecutive inference windows, eliminating false
positives from single-frame model fluctuations.

**What changed:**
- **[NEW] [`src/inference/alert_state_machine.py`](https://github.com/lukaszjecek/human-behavior-recognition-in-video-streams/blob/75-feature-implement-per-track-alert-state-machine/src/inference/alert_state_machine.py)** — Core implementation. Defines `AlertState` enum (INACTIVE → CANDIDATE → ACTIVE → RESOLVED), `TrackAlertRecord` dataclass (per-track mutable state), `AlertRaisedEvent` frozen dataclass (emitted on ACTIVE transition), and `AlertStateMachine` class with configurable `persistence_threshold`, `resolve_threshold`, and `danger_labels`. Each `track_id` evolves independently so multiple subjects in a scene do not interfere with each other. The machine is deterministic — identical event sequences always produce identical transitions.
- **[NEW] [`tests/inference/test_alert_state_machine.py`](https://github.com/lukaszjecek/human-behavior-recognition-in-video-streams/blob/75-feature-implement-per-track-alert-state-machine/tests/inference/test_alert_state_machine.py)** — 26 focused tests covering all transition paths, per-track isolation, `danger_labels` filter, edge cases (threshold=1, resolve_threshold>1), batch processing via `process_events`, and constructor validation.

**Out of scope (intentional):** This PR does not wire `AlertStateMachine` into the live pipeline.

## Linked Issue
Closes #75

## Checklist
- [x] Changes were tested locally
- [x] CI passes
- [x] README/docs updated if relevant
- [x] Scope matches the linked Issue
- [x] No direct work outside the agreed scope