### PR TITLE
77 feature aggregate detection windows into business level events

### DIFF
--- a/src/inference/aggregator.py
+++ b/src/inference/aggregator.py
@@ -1,0 +1,233 @@
+"""Business event aggregation for action event streams.
+
+Groups consecutive ActionEvents with the same label for the same track
+into higher-level BusinessEvents with explicit start, end, and duration.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from src.inference.action_event import ActionEvent
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class BusinessEvent:
+    """Aggregated business-level event spanning multiple detection windows.
+
+    Attributes:
+        track_id: Optional tracking ID for multi-object tracking scenarios.
+        label: Action label shared by all windows in this event.
+        start_frame_index: Frame index from the first ActionEvent in the group.
+        end_frame_index: Frame index from the last ActionEvent in the group.
+        duration_windows: Number of ActionEvent windows aggregated into this event.
+        start_timestamp: Timestamp from the first ActionEvent, if available.
+        end_timestamp: Timestamp from the last ActionEvent, if available.
+        mean_confidence: Average confidence across all windows in the group.
+    """
+
+    track_id: Optional[int]
+    label: str
+    start_frame_index: int
+    end_frame_index: int
+    duration_windows: int
+    start_timestamp: Optional[float]
+    end_timestamp: Optional[float]
+    mean_confidence: float
+
+
+@dataclass
+class _TrackBuffer:
+    """Internal mutable buffer for an open event on one track.
+
+    Attributes:
+        label: The action label currently being accumulated.
+        events: Ordered list of ActionEvents for the open event.
+    """
+
+    label: str
+    events: list[ActionEvent]
+
+
+class EventAggregator:
+    """Per-track aggregator that groups consecutive same-label ActionEvents.
+
+    An open event is closed (a BusinessEvent is emitted) when:
+
+    - The incoming event has a different label, or
+    - There is a real gap between windows
+      (``event.start_frame_index > previous.end_frame_index + 1``).
+
+    Overlapping and adjacent windows are treated as continuous:
+
+    - Adjacent:   ``[0-15], [16-31]`` → ``16 <= 15 + 1`` ✓
+    - Overlapping: ``[0-15], [8-23]`` → ``8 <= 15 + 1`` ✓
+
+    Per-track isolation: every ``track_id`` (including ``None``) has its own
+    independent buffer, consistent with ``MajorityVoteSmoother`` and
+    ``AlertStateMachine`` conventions.
+
+    Example:
+        >>> aggregator = EventAggregator()
+        >>> e1 = ActionEvent(0, 15, "walk", 0.9)
+        >>> e2 = ActionEvent(16, 31, "walk", 0.8)
+        >>> aggregator.update(e1)  # None — event open
+        >>> aggregator.update(e2)  # None — same label, continuous
+        >>> e3 = ActionEvent(32, 47, "fight", 0.95)
+        >>> result = aggregator.update(e3)  # BusinessEvent for "walk"
+    """
+
+    def __init__(self) -> None:
+        """Initialize the aggregator with empty per-track buffers."""
+        self._buffers: dict[Optional[int], _TrackBuffer] = {}
+        logger.debug("EventAggregator initialized")
+
+    def update(self, event: ActionEvent) -> Optional[BusinessEvent]:
+        """Add event to the per-track buffer.
+
+        Returns a closed BusinessEvent when continuity breaks, None otherwise.
+
+        Args:
+            event: Incoming ActionEvent to process.
+
+        Returns:
+            A BusinessEvent if the arrival of this event closes an existing open
+            event (label change or frame gap), ``None`` otherwise.
+
+        Raises:
+            TypeError: If ``event`` is not an ``ActionEvent`` instance.
+        """
+        if not isinstance(event, ActionEvent):
+            raise TypeError(
+                f"event must be an ActionEvent instance, got {type(event).__name__}"
+            )
+
+        track_id = event.track_id
+
+        if track_id not in self._buffers:
+            self._buffers[track_id] = _TrackBuffer(label=event.label, events=[event])
+            logger.debug("Track %s: opened new event label=%r", track_id, event.label)
+            return None
+
+        buf = self._buffers[track_id]
+        prev = buf.events[-1]
+        label_changed = event.label != buf.label
+        gap_detected = event.start_frame_index > prev.end_frame_index + 1
+
+        if label_changed or gap_detected:
+            closed = self._close_buffer(track_id, buf)
+            logger.debug(
+                "Track %s: closed event label=%r windows=%d (label_changed=%s, gap=%s)",
+                track_id,
+                closed.label,
+                closed.duration_windows,
+                label_changed,
+                gap_detected,
+            )
+            self._buffers[track_id] = _TrackBuffer(label=event.label, events=[event])
+            logger.debug("Track %s: opened new event label=%r", track_id, event.label)
+            return closed
+
+        buf.events.append(event)
+        logger.debug(
+            "Track %s: extended event label=%r windows=%d",
+            track_id,
+            buf.label,
+            len(buf.events),
+        )
+        return None
+
+    def flush(self, track_id: Optional[int] = None) -> list[BusinessEvent]:
+        """Force-close open events and clear their buffered state.
+
+        Args:
+            track_id: If a non-``None`` integer is provided, flush only that
+                track's open event.  If ``None`` (the default), flush all open
+                tracks.
+
+        Returns:
+            List of closed BusinessEvents.  When flushing all tracks, events
+            are returned in deterministic order: integer track_ids sorted
+            ascending, ``None`` last.
+        """
+        if track_id is not None:
+            buf = self._buffers.pop(track_id, None)
+            if buf is None:
+                return []
+            result = self._close_buffer(track_id, buf)
+            logger.debug(
+                "Track %s: flushed event label=%r windows=%d",
+                track_id,
+                result.label,
+                result.duration_windows,
+            )
+            return [result]
+
+        if not self._buffers:
+            return []
+
+        int_ids = sorted(tid for tid in self._buffers if tid is not None)
+        ordered: list[Optional[int]] = int_ids + ([None] if None in self._buffers else [])
+
+        results: list[BusinessEvent] = []
+        for tid in ordered:
+            buf = self._buffers[tid]
+            be = self._close_buffer(tid, buf)
+            results.append(be)
+            logger.debug(
+                "Track %s: flushed event label=%r windows=%d",
+                tid,
+                be.label,
+                be.duration_windows,
+            )
+
+        self._buffers.clear()
+        return results
+
+    def reset(self, track_id: Optional[int] = None) -> None:
+        """Discard buffered state without emitting BusinessEvents.
+
+        Args:
+            track_id: If a non-``None`` integer is provided, reset only that
+                track's buffer.  If ``None`` (the default), reset all tracks.
+        """
+        if track_id is not None:
+            self._buffers.pop(track_id, None)
+            logger.debug("EventAggregator: track %s buffer discarded", track_id)
+        else:
+            self._buffers.clear()
+            logger.debug("EventAggregator: all track buffers discarded")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _close_buffer(track_id: Optional[int], buf: _TrackBuffer) -> BusinessEvent:
+        """Build a BusinessEvent from a completed buffer.
+
+        Args:
+            track_id: Track identifier for the resulting event.
+            buf: Completed track buffer containing at least one event.
+
+        Returns:
+            Frozen BusinessEvent summarising all buffered windows.
+        """
+        first = buf.events[0]
+        last = buf.events[-1]
+        mean_conf = sum(e.confidence for e in buf.events) / len(buf.events)
+        return BusinessEvent(
+            track_id=track_id,
+            label=buf.label,
+            start_frame_index=first.start_frame_index,
+            end_frame_index=last.end_frame_index,
+            duration_windows=len(buf.events),
+            start_timestamp=first.start_timestamp,
+            end_timestamp=last.end_timestamp,
+            mean_confidence=mean_conf,
+        )
+
+
+__all__ = ["BusinessEvent", "EventAggregator"]

--- a/tests/inference/test_aggregator.py
+++ b/tests/inference/test_aggregator.py
@@ -1,0 +1,290 @@
+from typing import Optional
+
+import pytest
+
+from src.inference.action_event import ActionEvent
+from src.inference.aggregator import BusinessEvent, EventAggregator
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _evt(
+    label: str,
+    track_id: Optional[int] = None,
+    start: int = 0,
+    end: int = 15,
+    confidence: float = 0.9,
+    start_ts: Optional[float] = None,
+    end_ts: Optional[float] = None,
+) -> ActionEvent:
+    return ActionEvent(
+        start_frame_index=start,
+        end_frame_index=end,
+        label=label,
+        confidence=confidence,
+        track_id=track_id,
+        start_timestamp=start_ts,
+        end_timestamp=end_ts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Single / double window — no close
+# ---------------------------------------------------------------------------
+
+
+def test_single_window_returns_none():
+    agg = EventAggregator()
+    assert agg.update(_evt("walk")) is None
+
+
+def test_two_windows_same_label_returns_none():
+    agg = EventAggregator()
+    agg.update(_evt("walk", start=0, end=15))
+    result = agg.update(_evt("walk", start=16, end=31))
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Label change
+# ---------------------------------------------------------------------------
+
+
+def test_label_change_closes_event():
+    agg = EventAggregator()
+    agg.update(_evt("walk", start=0, end=15))
+    agg.update(_evt("walk", start=16, end=31))
+    result = agg.update(_evt("fight", start=32, end=47))
+    assert isinstance(result, BusinessEvent)
+    assert result.label == "walk"
+
+
+def test_label_change_starts_new_event():
+    agg = EventAggregator()
+    agg.update(_evt("walk", start=0, end=15))
+    agg.update(_evt("fight", start=16, end=31))  # closes "walk", opens "fight"
+    result = agg.update(_evt("run", start=32, end=47))  # closes "fight"
+    assert isinstance(result, BusinessEvent)
+    assert result.label == "fight"
+
+
+# ---------------------------------------------------------------------------
+# Continuity rules
+# ---------------------------------------------------------------------------
+
+
+def test_gap_between_windows_closes_event():
+    agg = EventAggregator()
+    agg.update(_evt("walk", start=0, end=15))
+    # 20 > 15 + 1 → gap detected
+    result = agg.update(_evt("walk", start=20, end=35))
+    assert isinstance(result, BusinessEvent)
+    assert result.label == "walk"
+
+
+def test_overlapping_windows_are_continuous():
+    agg = EventAggregator()
+    agg.update(_evt("walk", start=0, end=15))
+    # 8 <= 15 + 1 → continuous
+    result = agg.update(_evt("walk", start=8, end=23))
+    assert result is None
+
+
+def test_adjacent_windows_are_continuous():
+    agg = EventAggregator()
+    agg.update(_evt("walk", start=0, end=15))
+    # 16 == 15 + 1 → continuous
+    result = agg.update(_evt("walk", start=16, end=31))
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# BusinessEvent field correctness
+# ---------------------------------------------------------------------------
+
+
+def test_business_event_start_end_frames():
+    agg = EventAggregator()
+    agg.update(_evt("walk", start=10, end=25))
+    agg.update(_evt("walk", start=26, end=41))
+    result = agg.update(_evt("fight", start=42, end=57))
+    assert result is not None
+    assert result.start_frame_index == 10
+    assert result.end_frame_index == 41
+
+
+def test_business_event_duration_windows():
+    agg = EventAggregator()
+    agg.update(_evt("walk", start=0, end=15))
+    agg.update(_evt("walk", start=16, end=31))
+    agg.update(_evt("walk", start=32, end=47))
+    result = agg.update(_evt("fight", start=48, end=63))
+    assert result is not None
+    assert result.duration_windows == 3
+
+
+def test_business_event_mean_confidence():
+    agg = EventAggregator()
+    agg.update(_evt("walk", start=0, end=15, confidence=0.6))
+    agg.update(_evt("walk", start=16, end=31, confidence=0.8))
+    agg.update(_evt("walk", start=32, end=47, confidence=1.0))
+    result = agg.update(_evt("fight", start=48, end=63))
+    assert result is not None
+    assert abs(result.mean_confidence - 0.8) < 1e-9
+
+
+def test_business_event_timestamps():
+    agg = EventAggregator()
+    agg.update(_evt("walk", start=0, end=15, start_ts=0.0, end_ts=0.5))
+    agg.update(_evt("walk", start=16, end=31, start_ts=0.5, end_ts=1.0))
+    result = agg.update(_evt("fight", start=32, end=47, start_ts=1.0, end_ts=1.5))
+    assert result is not None
+    assert result.start_timestamp == 0.0
+    assert result.end_timestamp == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Per-track isolation
+# ---------------------------------------------------------------------------
+
+
+def test_track_isolation():
+    agg = EventAggregator()
+    agg.update(_evt("walk", track_id=1, start=0, end=15))
+    agg.update(_evt("walk", track_id=1, start=16, end=31))
+    agg.update(_evt("fight", track_id=2, start=0, end=15))
+
+    result1 = agg.update(_evt("fight", track_id=1, start=32, end=47))
+    assert isinstance(result1, BusinessEvent)
+    assert result1.label == "walk"
+    assert result1.track_id == 1
+
+    result2 = agg.update(_evt("fight", track_id=2, start=16, end=31))
+    assert result2 is None
+
+
+def test_none_track_id_handled():
+    agg = EventAggregator()
+    agg.update(_evt("walk", track_id=None, start=0, end=15))
+    result = agg.update(_evt("fight", track_id=None, start=16, end=31))
+    assert isinstance(result, BusinessEvent)
+    assert result.track_id is None
+    assert result.label == "walk"
+
+
+# ---------------------------------------------------------------------------
+# flush
+# ---------------------------------------------------------------------------
+
+
+def test_flush_all_returns_open_events():
+    agg = EventAggregator()
+    agg.update(_evt("walk", track_id=1, start=0, end=15))
+    agg.update(_evt("fight", track_id=2, start=0, end=15))
+    results = agg.flush()
+    assert len(results) == 2
+    labels = {r.label for r in results}
+    assert labels == {"walk", "fight"}
+
+
+def test_flush_clears_buffered_state():
+    agg = EventAggregator()
+    agg.update(_evt("walk", start=0, end=15))
+    agg.flush()
+    # After flush, no open event — next update opens a fresh one
+    result = agg.update(_evt("walk", start=16, end=31))
+    assert result is None
+    results = agg.flush()
+    assert len(results) == 1
+    assert results[0].duration_windows == 1
+
+
+def test_flush_single_track():
+    agg = EventAggregator()
+    agg.update(_evt("walk", track_id=1, start=0, end=15))
+    agg.update(_evt("fight", track_id=2, start=0, end=15))
+
+    results = agg.flush(track_id=1)
+    assert len(results) == 1
+    assert results[0].track_id == 1
+    assert results[0].label == "walk"
+
+    # Track 2 still open
+    remaining = agg.flush()
+    assert len(remaining) == 1
+    assert remaining[0].track_id == 2
+
+
+def test_flush_empty_returns_empty_list():
+    agg = EventAggregator()
+    assert agg.flush() == []
+
+
+def test_flush_deterministic_order():
+    agg = EventAggregator()
+    agg.update(_evt("a", track_id=3, start=0, end=15))
+    agg.update(_evt("b", track_id=1, start=0, end=15))
+    agg.update(_evt("c", track_id=None, start=0, end=15))
+    agg.update(_evt("d", track_id=2, start=0, end=15))
+
+    results = agg.flush()
+    assert len(results) == 4
+    assert [r.track_id for r in results] == [1, 2, 3, None]
+
+
+# ---------------------------------------------------------------------------
+# reset
+# ---------------------------------------------------------------------------
+
+
+def test_reset_discards_without_emitting():
+    agg = EventAggregator()
+    agg.update(_evt("walk", start=0, end=15))
+    agg.reset()
+    assert agg.flush() == []
+
+
+# ---------------------------------------------------------------------------
+# Sequences
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_splits_in_sequence():
+    agg = EventAggregator()
+
+    agg.update(_evt("walk", start=0, end=15))
+    agg.update(_evt("walk", start=16, end=31))
+    e1 = agg.update(_evt("fight", start=32, end=47))
+    assert e1 is not None and e1.label == "walk" and e1.duration_windows == 2
+
+    agg.update(_evt("fight", start=48, end=63))
+    e2 = agg.update(_evt("run", start=64, end=79))
+    assert e2 is not None and e2.label == "fight" and e2.duration_windows == 2
+
+    results = agg.flush()
+    assert len(results) == 1
+    assert results[0].label == "run"
+
+
+def test_single_window_flush():
+    agg = EventAggregator()
+    agg.update(_evt("walk", start=0, end=15))
+    results = agg.flush()
+    assert len(results) == 1
+    assert results[0].duration_windows == 1
+    assert results[0].label == "walk"
+    assert results[0].start_frame_index == 0
+    assert results[0].end_frame_index == 15
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_event_raises():
+    agg = EventAggregator()
+    with pytest.raises(TypeError, match="ActionEvent"):
+        agg.update("not an event")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
Implements a per-track event aggregator that converts consecutive low-level inference windows into higher-level business events with explicit start, end, duration, and track-aware continuity.

**What changed:**
- **[NEW] [`src/inference/aggregator.py`](https://github.com/lukaszjecek/human-behavior-recognition-in-video-streams/blob/77-feature-aggregate-detection-windows-into-business-level-events/src/inference/aggregator.py)** — `BusinessEvent` frozen dataclass and `EventAggregator` class with per-track isolated buffers. An open event is closed when label changes or a real frame gap is detected. Sliding-window continuity rule: overlapping and adjacent windows are treated as continuous (`current.start_frame_index <= previous.end_frame_index + 1`), only actual gaps trigger a split. `flush()` force-closes all open events with deterministic output order (integer track_ids ascending, `None` last). `reset()` discards buffered state without emitting events.
- **[NEW] [`tests/inference/test_aggregator.py`](https://github.com/lukaszjecek/human-behavior-recognition-in-video-streams/blob/77-feature-aggregate-detection-windows-into-business-level-events/tests/inference/test_aggregator.py)** — 22 focused tests covering label change splits, frame gap splits, overlapping and adjacent window continuity, per-track isolation, `flush()` semantics and deterministic ordering, `reset()` behavior, and `BusinessEvent` field correctness.

**Integration contract:** `update()` returns `Optional[BusinessEvent]` — the aggregated output is ready for consumption by backend consumers. Wiring into the live pipeline is intentionally out of scope for this issue.

**Out of scope (intentional):** This PR does not modify `ActionEvent`, `MajorityVoteSmoother`, `AlertStateMachine`, or any existing module.


## Testing
- verified with:
  - `python -m pytest tests/inference/test_aggregator.py -v` — 22 passed
  - `python -m pytest tests/inference -q` — all passed
- tests cover: label change splits, frame gap splits, overlapping/adjacent
  window continuity, per-track isolation, `flush()` semantics and ordering,
  `reset()` behavior, and `BusinessEvent` field correctness

## Linked Issue
Closes #77

## Checklist
- [x] Changes were tested locally
- [x] CI passes
- [x] README/docs updated if relevant
- [x] Scope matches the linked Issue
- [x] No direct work outside the agreed scope