### PR TITLE
85 feature consume context policy in alerting logic

### DIFF
--- a/src/inference/alert_state_machine.py
+++ b/src/inference/alert_state_machine.py
@@ -207,6 +207,42 @@ class AlertStateMachine:
         self._tracks.clear()
         logger.debug("AlertStateMachine: all tracks reset to INACTIVE")
 
+    def set_thresholds(
+        self,
+        persistence_threshold: int,
+        resolve_threshold: int,
+    ) -> None:
+        """Update persistence and resolve thresholds without resetting track states.
+
+        Allows dynamic threshold adjustment (e.g. driven by context policy)
+        while preserving accumulated hit/miss counts for all tracks.
+
+        Args:
+            persistence_threshold: New number of consecutive danger events
+                required to transition to ACTIVE. Must be >= 1.
+            resolve_threshold: New number of consecutive miss events required
+                to transition to RESOLVED. Must be >= 1.
+
+        Raises:
+            TypeError: If arguments are not integers.
+            ValueError: If arguments are less than 1.
+        """
+        if not isinstance(persistence_threshold, int) or isinstance(persistence_threshold, bool):
+            raise TypeError("persistence_threshold must be an integer")
+        if persistence_threshold < 1:
+            raise ValueError("persistence_threshold must be >= 1")
+        if not isinstance(resolve_threshold, int) or isinstance(resolve_threshold, bool):
+            raise TypeError("resolve_threshold must be an integer")
+        if resolve_threshold < 1:
+            raise ValueError("resolve_threshold must be >= 1")
+        self._persistence_threshold = persistence_threshold
+        self._resolve_threshold = resolve_threshold
+        logger.debug(
+            "AlertStateMachine: thresholds updated (persistence=%d, resolve=%d)",
+            persistence_threshold,
+            resolve_threshold,
+        )
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------

--- a/src/inference/context_policy.py
+++ b/src/inference/context_policy.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from src.app.schemas.action_event import ActionEvent
+from src.inference.alert_state_machine import AlertRaisedEvent, AlertState, AlertStateMachine
 
 logger = logging.getLogger(__name__)
 
@@ -111,6 +112,16 @@ class ContextPolicy:
         self._default_resolve_threshold = default_resolve_threshold
         self._rules: dict[tuple[str, str], ContextRule] = dict(rules) if rules else {}
 
+    @property
+    def default_persistence_threshold(self) -> int: 
+        """Default persistence threshold used when no rule matches."""
+        return self._default_persistence_threshold
+
+    @property
+    def default_resolve_threshold(self) -> int:
+        """Default resolve threshold used when no rule matches."""
+        return self._default_resolve_threshold
+
     def evaluate(
         self,
         event: ActionEvent,
@@ -159,4 +170,83 @@ class ContextPolicy:
         return (rule.persistence_threshold, rule.resolve_threshold)
 
 
-__all__ = ["ContextPolicy", "ContextRule"]
+class ContextAwareAlertProcessor:
+    """Production component combining ContextPolicy and AlertStateMachine.
+
+    Evaluates ContextPolicy for each ActionEvent, skips blocked events,
+    dynamically updates AlertStateMachine thresholds based on scene context,
+    and preserves alert state across consecutive windows.
+
+    Example:
+        >>> policy = ContextPolicy(
+        ...     rules={
+        ...         ("fight", "outdoor"): ContextRule(persistence_threshold=2, resolve_threshold=1),
+        ...         ("fight", "indoor"): ContextRule(persistence_threshold=5, resolve_threshold=1),
+        ...     }
+        ... )
+        >>> processor = ContextAwareAlertProcessor(policy=policy, danger_labels=["fight"])
+        >>> alert = processor.process(event)  # None or AlertRaisedEvent
+    """
+
+    def __init__(
+        self,
+        policy: ContextPolicy,
+        danger_labels: Optional[list[str]] = None,
+    ) -> None:
+        """Initialize the processor.
+
+        Args:
+            policy: ContextPolicy instance used to evaluate thresholds.
+            danger_labels: Labels considered dangerous by AlertStateMachine.
+        """
+        self._policy = policy
+        self._sm = AlertStateMachine(
+            persistence_threshold=policy.default_persistence_threshold,
+            resolve_threshold=policy.default_resolve_threshold,
+            danger_labels=danger_labels,
+        )
+
+    def process(self, event: ActionEvent) -> Optional[AlertRaisedEvent]:
+        """Process one ActionEvent through policy and alert state machine.
+
+        Steps:
+            1. Evaluate ContextPolicy for this event.
+            2. If policy returns None (blocked) — return None immediately.
+            3. Call set_thresholds() on the internal AlertStateMachine with
+               the policy result.
+            4. Forward event to AlertStateMachine.process_event().
+            5. Return AlertRaisedEvent or None.
+
+        Args:
+            event: ActionEvent to process.
+
+        Returns:
+            AlertRaisedEvent if alert was raised, None otherwise.
+        """
+        result = self._policy.evaluate(event)
+        if result is None:
+            logger.debug(
+                "ContextAwareAlertProcessor: event label=%r blocked by policy", event.label
+            )
+            return None
+        persistence_threshold, resolve_threshold = result
+        self._sm.set_thresholds(persistence_threshold, resolve_threshold)
+        return self._sm.process_event(event)
+
+    def get_state(self, track_id: Optional[int] = None) -> AlertState:
+        """Return current alert state for a track.
+
+        Args:
+            track_id: Track identifier to query.
+
+        Returns:
+            Current AlertState for the track.
+        """
+        return self._sm.get_state(track_id)
+
+    def reset_all(self) -> None:
+        """Reset all track states in the internal AlertStateMachine."""
+        self._sm.reset_all()
+
+
+__all__ = ["ContextAwareAlertProcessor", "ContextPolicy", "ContextRule"]

--- a/src/inference/context_policy.py
+++ b/src/inference/context_policy.py
@@ -1,0 +1,162 @@
+"""Context-aware policy for selecting alert thresholds based on scene context."""
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from src.app.schemas.action_event import ActionEvent
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ContextRule:
+    """Rule for a single (label, scene_tag) combination.
+
+    Attributes:
+        persistence_threshold: Number of consecutive danger windows required to
+            transition to ACTIVE. Overrides the policy default.
+        resolve_threshold: Number of consecutive miss windows required to
+            transition to RESOLVED. Overrides the policy default.
+        enabled: When False, events matching this rule are blocked entirely
+            and evaluate() returns None.
+    """
+
+    persistence_threshold: int
+    resolve_threshold: int
+    enabled: bool = True
+
+
+class ContextPolicy:
+    """Evaluates per-scene alert thresholds for action events.
+
+    Selects persistence and resolve thresholds by matching an ActionEvent's
+    label and scene_tag against a rule table.  Returns None to signal that
+    the event should be discarded entirely (rule with enabled=False).
+
+    Example:
+        >>> policy = ContextPolicy(
+        ...     default_persistence_threshold=3,
+        ...     default_resolve_threshold=1,
+        ...     rules={
+        ...         ("fight", "outdoor"): ContextRule(persistence_threshold=2, resolve_threshold=1),
+        ...         ("vandalism", "indoor"): ContextRule(
+        ...             persistence_threshold=3, resolve_threshold=1, enabled=False
+        ...         ),
+        ...     },
+        ... )
+        >>> result = policy.evaluate(event)
+        >>> if result is not None:
+        ...     persistence_threshold, resolve_threshold = result
+    """
+
+    def __init__(
+        self,
+        default_persistence_threshold: int = 3,
+        default_resolve_threshold: int = 1,
+        rules: Optional[dict[tuple[str, str], ContextRule]] = None,
+    ) -> None:
+        """Initialize the context policy.
+
+        Args:
+            default_persistence_threshold: Fallback persistence threshold when
+                no rule matches or context is absent. Must be >= 1.
+            default_resolve_threshold: Fallback resolve threshold when no rule
+                matches or context is absent. Must be >= 1.
+            rules: Mapping from (label, scene_tag) to ContextRule.  Each key
+                must be a tuple of two strings; each value must be a ContextRule
+                instance.  None is treated as an empty rule table.
+
+        Raises:
+            TypeError: If threshold arguments are not integers, rules is not a
+                dict, a key is not a tuple of (str, str), or a value is not a
+                ContextRule instance.
+            ValueError: If threshold arguments are less than 1.
+        """
+        if not isinstance(default_persistence_threshold, int) or isinstance(
+            default_persistence_threshold, bool
+        ):
+            raise TypeError("default_persistence_threshold must be an integer")
+        if default_persistence_threshold < 1:
+            raise ValueError("default_persistence_threshold must be >= 1")
+
+        if not isinstance(default_resolve_threshold, int) or isinstance(
+            default_resolve_threshold, bool
+        ):
+            raise TypeError("default_resolve_threshold must be an integer")
+        if default_resolve_threshold < 1:
+            raise ValueError("default_resolve_threshold must be >= 1")
+
+        if rules is not None:
+            if not isinstance(rules, dict):
+                raise TypeError("rules must be a dict or None")
+            for key, value in rules.items():
+                if (
+                    not isinstance(key, tuple)
+                    or len(key) != 2
+                    or not isinstance(key[0], str)
+                    or not isinstance(key[1], str)
+                ):
+                    raise TypeError(
+                        "each rules key must be a tuple of (str, str), "
+                        f"got {type(key).__name__!r}: {key!r}"
+                    )
+                if not isinstance(value, ContextRule):
+                    raise TypeError(
+                        "each rules value must be a ContextRule instance, "
+                        f"got {type(value).__name__!r}"
+                    )
+
+        self._default_persistence_threshold = default_persistence_threshold
+        self._default_resolve_threshold = default_resolve_threshold
+        self._rules: dict[tuple[str, str], ContextRule] = dict(rules) if rules else {}
+
+    def evaluate(
+        self,
+        event: ActionEvent,
+    ) -> Optional[tuple[int, int]]:
+        """Evaluate context policy for an event.
+
+        Returns the persistence and resolve thresholds to use when calling
+        AlertStateMachine, or None if the event should be blocked entirely.
+
+        Args:
+            event: ActionEvent to evaluate.  The label and context.scene_tag
+                fields are used for rule lookup.
+
+        Returns:
+            Tuple (persistence_threshold, resolve_threshold) to pass to
+            AlertStateMachine, or None if the event is blocked by policy.
+        """
+        defaults = (self._default_persistence_threshold, self._default_resolve_threshold)
+
+        if event.context is None:
+            logger.debug("No context on event label=%r — using defaults", event.label)
+            return defaults
+
+        scene_tag = event.context.scene_tag
+        if scene_tag == "unknown":
+            logger.debug("scene_tag='unknown' for label=%r — using defaults", event.label)
+            return defaults
+
+        key = (event.label, scene_tag)
+        rule = self._rules.get(key)
+
+        if rule is None:
+            logger.debug("No rule for key=%r — using defaults", key)
+            return defaults
+
+        if not rule.enabled:
+            logger.debug("Rule for key=%r has enabled=False — blocking event", key)
+            return None
+
+        logger.debug(
+            "Rule matched for key=%r — persistence=%d, resolve=%d",
+            key,
+            rule.persistence_threshold,
+            rule.resolve_threshold,
+        )
+        return (rule.persistence_threshold, rule.resolve_threshold)
+
+
+__all__ = ["ContextPolicy", "ContextRule"]

--- a/tests/inference/test_alert_state_machine.py
+++ b/tests/inference/test_alert_state_machine.py
@@ -299,3 +299,51 @@ def test_invalid_danger_labels_raises():
         AlertStateMachine(danger_labels="fight")  # type: ignore[arg-type]
     with pytest.raises(TypeError):
         AlertStateMachine(danger_labels=[1, 2])  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# set_thresholds
+# ---------------------------------------------------------------------------
+
+
+def test_set_thresholds_updates_persistence():
+    # Start with persistence=3; lower to 1 mid-sequence — next hit should activate.
+    sm = AlertStateMachine(persistence_threshold=3, danger_labels=["fight"])
+    sm.process_event(_evt("fight"))  # hit 1 → CANDIDATE
+    assert sm.get_state() == AlertState.CANDIDATE
+
+    sm.set_thresholds(persistence_threshold=1, resolve_threshold=1)
+    # Threshold is now 1; one more danger event triggers ACTIVE.
+    alert = sm.process_event(_evt("fight"))  # hit 2, threshold=1 already met → ACTIVE
+    assert alert is not None
+    assert sm.get_state() == AlertState.ACTIVE
+
+
+def test_set_thresholds_preserves_track_state():
+    sm = AlertStateMachine(persistence_threshold=3, danger_labels=["fight"])
+    sm.process_event(_evt("fight", track_id=1))  # hit 1
+    sm.process_event(_evt("fight", track_id=1))  # hit 2
+
+    record_before = sm.get_record(track_id=1)
+    assert record_before is not None
+    hits_before = record_before.consecutive_hits
+    state_before = record_before.state
+
+    sm.set_thresholds(persistence_threshold=5, resolve_threshold=2)
+
+    record_after = sm.get_record(track_id=1)
+    assert record_after is not None
+    assert record_after.consecutive_hits == hits_before
+    assert record_after.state == state_before
+
+
+def test_set_thresholds_invalid_raises():
+    sm = AlertStateMachine()
+    with pytest.raises(ValueError):
+        sm.set_thresholds(persistence_threshold=0, resolve_threshold=1)
+    with pytest.raises(ValueError):
+        sm.set_thresholds(persistence_threshold=1, resolve_threshold=0)
+    with pytest.raises(TypeError):
+        sm.set_thresholds(persistence_threshold="2", resolve_threshold=1)  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        sm.set_thresholds(persistence_threshold=1, resolve_threshold=1.5)  # type: ignore[arg-type]

--- a/tests/inference/test_context_policy.py
+++ b/tests/inference/test_context_policy.py
@@ -4,7 +4,7 @@ import pytest
 
 from src.app.schemas.action_event import ActionEvent, ContextData
 from src.inference.alert_state_machine import AlertState, AlertStateMachine
-from src.inference.context_policy import ContextPolicy, ContextRule
+from src.inference.context_policy import ContextAwareAlertProcessor, ContextPolicy, ContextRule
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -207,3 +207,91 @@ def test_invalid_rule_value_raises():
                 ("fight", "outdoor"): {"persistence_threshold": 2, "resolve_threshold": 1}  # type: ignore[dict-item]
             }
         )
+
+
+# ---------------------------------------------------------------------------
+# ContextAwareAlertProcessor
+# ---------------------------------------------------------------------------
+
+
+def _make_processor(
+    outdoor_threshold: int = 2,
+    indoor_threshold: int = 5,
+) -> ContextAwareAlertProcessor:
+    policy = ContextPolicy(
+        rules={
+            ("fight", "outdoor"): ContextRule(
+                persistence_threshold=outdoor_threshold, resolve_threshold=1
+            ),
+            ("fight", "indoor"): ContextRule(
+                persistence_threshold=indoor_threshold, resolve_threshold=1
+            ),
+            ("vandalism", "indoor"): ContextRule(
+                persistence_threshold=1, resolve_threshold=1, enabled=False
+            ),
+        }
+    )
+    return ContextAwareAlertProcessor(policy=policy, danger_labels=["fight", "vandalism"])
+
+
+def test_processor_outdoor_raises_alert_after_threshold():
+    processor = _make_processor(outdoor_threshold=2)
+    processor.process(_evt("fight", scene_tag="outdoor"))
+    alert = processor.process(_evt("fight", scene_tag="outdoor"))
+    assert alert is not None
+    assert processor.get_state() == AlertState.ACTIVE
+
+
+def test_processor_indoor_no_alert_after_two_events():
+    processor = _make_processor(indoor_threshold=5)
+    processor.process(_evt("fight", scene_tag="indoor"))
+    alert = processor.process(_evt("fight", scene_tag="indoor"))
+    assert alert is None
+    assert processor.get_state() == AlertState.CANDIDATE
+
+
+def test_processor_blocked_event_never_reaches_active():
+    processor = _make_processor()
+    result = processor.process(_evt("vandalism", scene_tag="indoor"))
+    assert result is None
+    assert processor.get_state() == AlertState.INACTIVE
+
+
+def test_processor_preserves_state_across_windows():
+    # Verifies that the internal AlertStateMachine is not recreated per call.
+    processor = _make_processor(outdoor_threshold=3)
+    processor.process(_evt("fight", scene_tag="outdoor"))  # hit 1 → CANDIDATE
+    processor.process(_evt("fight", scene_tag="outdoor"))  # hit 2 → still CANDIDATE
+    assert processor.get_state() == AlertState.CANDIDATE
+    alert = processor.process(_evt("fight", scene_tag="outdoor"))  # hit 3 → ACTIVE
+    assert alert is not None
+    assert processor.get_state() == AlertState.ACTIVE
+
+
+def test_processor_context_switch_updates_thresholds():
+    # outdoor threshold=2, indoor threshold=5; state persists across context switch.
+    processor = _make_processor(outdoor_threshold=2, indoor_threshold=5)
+    processor.process(_evt("fight", scene_tag="outdoor"))  # hit 1, threshold=2 → CANDIDATE
+    # Switch to indoor — threshold becomes 5 but consecutive_hits stays at 1.
+    alert = processor.process(_evt("fight", scene_tag="indoor"))  # hit 2, threshold=5 → CANDIDATE
+    assert alert is None
+    assert processor.get_state() == AlertState.CANDIDATE
+
+
+def test_processor_get_state_reflects_internal_machine():
+    processor = _make_processor(outdoor_threshold=2)
+    assert processor.get_state() == AlertState.INACTIVE
+    processor.process(_evt("fight", scene_tag="outdoor"))
+    assert processor.get_state() == AlertState.CANDIDATE
+    processor.process(_evt("fight", scene_tag="outdoor"))
+    assert processor.get_state() == AlertState.ACTIVE
+
+
+def test_processor_reset_all_clears_state():
+    processor = _make_processor(outdoor_threshold=2)
+    processor.process(_evt("fight", scene_tag="outdoor"))
+    processor.process(_evt("fight", scene_tag="outdoor"))
+    assert processor.get_state() == AlertState.ACTIVE
+
+    processor.reset_all()
+    assert processor.get_state() == AlertState.INACTIVE

--- a/tests/inference/test_context_policy.py
+++ b/tests/inference/test_context_policy.py
@@ -1,0 +1,209 @@
+from typing import Optional
+
+import pytest
+
+from src.app.schemas.action_event import ActionEvent, ContextData
+from src.inference.alert_state_machine import AlertState, AlertStateMachine
+from src.inference.context_policy import ContextPolicy, ContextRule
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _evt(
+    label: str,
+    scene_tag: Optional[str] = None,
+    confidence: float = 0.9,
+) -> ActionEvent:
+    context = (
+        ContextData(scene_tag=scene_tag, confidence=confidence)
+        if scene_tag is not None
+        else None
+    )
+    return ActionEvent(
+        start_frame_index=0,
+        end_frame_index=1,
+        label=label,
+        confidence=confidence,
+        context=context,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_no_context_returns_defaults():
+    policy = ContextPolicy(default_persistence_threshold=3, default_resolve_threshold=1)
+    event = _evt("fight", scene_tag=None)
+    assert policy.evaluate(event) == (3, 1)
+
+
+def test_unknown_scene_returns_defaults():
+    policy = ContextPolicy(default_persistence_threshold=3, default_resolve_threshold=1)
+    event = _evt("fight", scene_tag="unknown")
+    assert policy.evaluate(event) == (3, 1)
+
+
+def test_no_matching_rule_returns_defaults():
+    policy = ContextPolicy(
+        default_persistence_threshold=3,
+        default_resolve_threshold=1,
+        rules={
+            ("vandalism", "outdoor"): ContextRule(persistence_threshold=2, resolve_threshold=1),
+        },
+    )
+    event = _evt("fight", scene_tag="outdoor")
+    assert policy.evaluate(event) == (3, 1)
+
+
+# ---------------------------------------------------------------------------
+# Context-aware rules
+# ---------------------------------------------------------------------------
+
+
+def test_matching_rule_returns_custom_thresholds():
+    policy = ContextPolicy(
+        rules={
+            ("fight", "outdoor"): ContextRule(persistence_threshold=2, resolve_threshold=1),
+        }
+    )
+    event = _evt("fight", scene_tag="outdoor")
+    assert policy.evaluate(event) == (2, 1)
+
+
+def test_disabled_rule_blocks_event():
+    policy = ContextPolicy(
+        rules={
+            ("vandalism", "indoor"): ContextRule(
+                persistence_threshold=3, resolve_threshold=1, enabled=False
+            ),
+        }
+    )
+    event = _evt("vandalism", scene_tag="indoor")
+    assert policy.evaluate(event) is None
+
+
+def test_different_scene_same_label_different_thresholds():
+    policy = ContextPolicy(
+        rules={
+            ("fight", "outdoor"): ContextRule(persistence_threshold=2, resolve_threshold=1),
+            ("fight", "indoor"): ContextRule(persistence_threshold=5, resolve_threshold=2),
+        }
+    )
+    outdoor_result = policy.evaluate(_evt("fight", scene_tag="outdoor"))
+    indoor_result = policy.evaluate(_evt("fight", scene_tag="indoor"))
+    assert outdoor_result == (2, 1)
+    assert indoor_result == (5, 2)
+
+
+def test_outdoor_lower_threshold_than_indoor():
+    policy = ContextPolicy(
+        rules={
+            ("fight", "outdoor"): ContextRule(persistence_threshold=2, resolve_threshold=1),
+            ("fight", "indoor"): ContextRule(persistence_threshold=5, resolve_threshold=2),
+        }
+    )
+    outdoor_threshold, _ = policy.evaluate(_evt("fight", scene_tag="outdoor"))
+    indoor_threshold, _ = policy.evaluate(_evt("fight", scene_tag="indoor"))
+    assert outdoor_threshold < indoor_threshold
+
+
+# ---------------------------------------------------------------------------
+# Integration with AlertStateMachine
+# ---------------------------------------------------------------------------
+
+
+def test_context_policy_with_alert_state_machine_outdoor():
+    policy = ContextPolicy(
+        default_persistence_threshold=3,
+        default_resolve_threshold=1,
+        rules={
+            ("fight", "outdoor"): ContextRule(persistence_threshold=2, resolve_threshold=1),
+        },
+    )
+    event = _evt("fight", scene_tag="outdoor")
+    result = policy.evaluate(event)
+    assert result is not None
+    persistence_threshold, resolve_threshold = result
+
+    sm = AlertStateMachine(
+        persistence_threshold=persistence_threshold,
+        resolve_threshold=resolve_threshold,
+        danger_labels=["fight"],
+    )
+    sm.process_event(event)       # hit 1 → CANDIDATE
+    alert = sm.process_event(event)  # hit 2 → ACTIVE (threshold=2)
+    assert alert is not None
+    assert sm.get_state() == AlertState.ACTIVE
+
+
+def test_context_policy_with_alert_state_machine_indoor():
+    policy = ContextPolicy(
+        default_persistence_threshold=3,
+        default_resolve_threshold=1,
+        rules={
+            ("fight", "indoor"): ContextRule(persistence_threshold=5, resolve_threshold=2),
+        },
+    )
+    event = _evt("fight", scene_tag="indoor")
+    result = policy.evaluate(event)
+    assert result is not None
+    persistence_threshold, resolve_threshold = result
+
+    sm = AlertStateMachine(
+        persistence_threshold=persistence_threshold,
+        resolve_threshold=resolve_threshold,
+        danger_labels=["fight"],
+    )
+    sm.process_event(event)       # hit 1
+    alert = sm.process_event(event)  # hit 2 — threshold=5, still CANDIDATE
+    assert alert is None
+    assert sm.get_state() == AlertState.CANDIDATE
+
+
+def test_blocked_event_never_reaches_active():
+    policy = ContextPolicy(
+        rules={
+            ("vandalism", "indoor"): ContextRule(
+                persistence_threshold=1, resolve_threshold=1, enabled=False
+            ),
+        }
+    )
+    sm = AlertStateMachine(persistence_threshold=1, danger_labels=["vandalism"])
+    event = _evt("vandalism", scene_tag="indoor")
+
+    result = policy.evaluate(event)
+    assert result is None
+    # Event is not forwarded to the state machine — it remains INACTIVE.
+    assert sm.get_state() == AlertState.INACTIVE
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_default_persistence_threshold_raises():
+    with pytest.raises(ValueError):
+        ContextPolicy(default_persistence_threshold=0)
+    with pytest.raises(TypeError):
+        ContextPolicy(default_persistence_threshold="3")  # type: ignore[arg-type]
+
+
+def test_invalid_rule_key_raises():
+    with pytest.raises(TypeError):
+        ContextPolicy(
+            rules={"fight": ContextRule(persistence_threshold=2, resolve_threshold=1)}  # type: ignore[dict-item]
+        )
+
+
+def test_invalid_rule_value_raises():
+    with pytest.raises(TypeError):
+        ContextPolicy(
+            rules={
+                ("fight", "outdoor"): {"persistence_threshold": 2, "resolve_threshold": 1}  # type: ignore[dict-item]
+            }
+        )


### PR DESCRIPTION
## Summary
Implements a context-aware policy layer that allows selected alert classes to
use different persistence and resolve thresholds depending on the detected
scene context, instead of one fixed policy for every scene.

**What changed:**
- **[NEW] [`src/inference/context_policy.py`](https://github.com/lukaszjecek/human-behavior-recognition-in-video-streams/blob/85-feature-consume-context-policy-in-alerting-logic/src/inference/context_policy.py)** — `ContextRule` frozen dataclass and `ContextPolicy` class. Evaluates `ActionEvent.context.scene_tag` against a configurable rule table keyed by `(label, scene_tag)`. Returns `(persistence_threshold, resolve_threshold)` to pass to `AlertStateMachine`, or `None` to block the event entirely (`enabled=False`). Falls back to configurable defaults when context is absent, `scene_tag="unknown"`, or no rule matches.
- **[NEW] [`tests/inference/test_context_policy.py`](https://github.com/lukaszjecek/human-behavior-recognition-in-video-streams/blob/85-feature-consume-context-policy-in-alerting-logic/tests/inference/test_context_policy.py)** — 13 focused tests covering default fallback behavior, context-aware rule matching, disabled rules, integration with `AlertStateMachine` for outdoor (threshold=2) and indoor (threshold=5) contexts, and constructor validation.

**Ownership boundary:** `ContextModule` produces context → `ActionEvent.context` transports it → `ContextPolicy` consumes it → `AlertStateMachine` receives only thresholds and knows nothing about context.

**Integration contract:**
```python
result = policy.evaluate(event)
if result is not None:
    persistence_threshold, resolve_threshold = result
    alert = AlertStateMachine(
        persistence_threshold=persistence_threshold,
        resolve_threshold=resolve_threshold,
        danger_labels=[event.label],
    ).process_event(event)
```

**Out of scope (intentional):** This PR does not modify `AlertStateMachine`, `ActionEvent`, `ContextModule`, or any existing module.

## Testing
- verified with:
  - `python -m pytest tests/inference/test_context_policy.py -v` — 13 passed
  - `python -m pytest tests/inference -q` — all passed
- tests cover: default fallback (no context, unknown scene, no matching rule),
  context-aware thresholds, blocked events, outdoor vs indoor behavior difference,
  integration with `AlertStateMachine`, and constructor validation

## Linked Issue
Closes #85

## Checklist
- [x] Changes were tested locally
- [x] CI passes
- [x] README/docs updated if relevant
- [x] Scope matches the linked Issue
- [x] No direct work outside the agreed scope