### PR TITLE
88 chore add end to end smoke path for sprint 3 integrated system

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ The API now exposes endpoints for managing offline inference sessions asynchrono
 
 These endpoints use `asyncio.to_thread` for non-blocking execution and native `threading.Event` triggers down to the underlying inference loops to allow safe and clean interruptions without blocking the FastAPI event loop.
 
+### Integration Smoke Test
+
+To verify the entire integrated flow (**Source -> Inference -> Alert/Event -> API/WebSocket -> DB**) end-to-end after bringing up the services, run the automated integration smoke test script inside the running API container:
+
+```bash
+docker compose exec api python scripts/smoke_test.py
+```
+
+This script will dynamically create all necessary dummy weights and videos, run the inference session, listen via WebSockets for events, and confirm database persistence. For more details, see [Integration and DevOps](docs/integration-devops.md#sprint-3-integration-smoke-path).
+
 ### Configuration
 
 Backend configuration is managed through environment variables in `src/app/core/settings.py`:

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ These endpoints use `asyncio.to_thread` for non-blocking execution and native `t
 To verify the entire integrated flow (**Source -> Inference -> Alert/Event -> API/WebSocket -> DB**) end-to-end after bringing up the services, run the automated integration smoke test script inside the running API container:
 
 ```bash
-docker compose exec api python scripts/smoke_test.py
+docker compose exec api python scripts/integration_smoke_test.py
 ```
 
 This script will dynamically create all necessary dummy weights and videos, run the inference session, listen via WebSockets for events, and confirm database persistence. For more details, see [Integration and DevOps](docs/integration-devops.md#sprint-3-integration-smoke-path).

--- a/docs/integration-devops.md
+++ b/docs/integration-devops.md
@@ -314,3 +314,94 @@ log_dir: Path = "/app/data/logs"
 
 **Problem**: Database initialization fails
 - **Solution**: Remove volume and restart: `docker compose down -v && docker compose up --build`
+
+
+## Sprint 3 Integration Smoke Path
+
+To verify the correct setup, communication, and persistence of the entire integrated system, we have implemented an automated end-to-end smoke test path. 
+
+### Integrated Flow Chain
+The smoke path tests the following lifecycle:
+1. **Source / Input**: A 40-frame dummy video (`data/raw/smoke_sample.mp4`) is dynamically generated.
+2. **Inference**: A mock behavior model (`DummyBehaviorModel`) is dynamically created and stored under `data/logs/checkpoints/dummy_checkpoint.pth`.
+3. **API & WebSocket**: A FastAPI session is initiated via a REST HTTP POST request. A WebSocket client connects to `ws://localhost:8000/ws/live` and listens to live streamed events/alerts.
+4. **Processing**: The API runs the inference engine in a background thread, publishing frame detections and event payloads.
+5. **Database (DB)**: Detections and alerts are written in real-time to the PostgreSQL database via SQLAlchemy.
+6. **REST History**: The script queries the historical API `GET /api/events/?session_id=<session_id>` to confirm that all events have been correctly written to the database.
+
+### Running the Smoke Test
+
+1. **Spin up the multi-service stack**:
+   Make sure the Docker containers are built and running.
+   ```bash
+   docker compose up -d --build
+   ```
+
+2. **Execute the automated smoke script inside the API container**:
+   Since the container already installs all required packages (PyTorch, OpenCV, websockets, etc.), the easiest and most reliable way to run the smoke test is inside the `api` container.
+   ```bash
+   docker compose exec api python scripts/smoke_test.py
+   ```
+
+3. **Expected Output**:
+   When the smoke test completes successfully, you will see a detailed verification summary in your terminal:
+   ```text
+   ======================================================================
+   STARTING SPRINT 3 INTEGRATION SMOKE TEST
+   ======================================================================
+   [SMOKE TEST] Generated dummy checkpoint at: /app/data/logs/checkpoints/dummy_checkpoint.pth
+   [SMOKE TEST] Generated dummy video at: /app/data/raw/smoke_sample.mp4
+   [SMOKE TEST] Checking API health at http://localhost:8000/health...
+   [SMOKE TEST] API is healthy and responding.
+   [SMOKE TEST] Connecting to WebSocket: ws://localhost:8000/ws/live
+   [SMOKE TEST] WebSocket connected successfully. Listening for live events...
+   [SMOKE TEST] Starting session via POST /api/sessions/
+   [SMOKE TEST] Session created successfully. ID: 1e571dbb-2041-419b-a249-14a01c873428
+   [SMOKE TEST] Monitoring session status...
+   [SMOKE TEST] Session Status: running
+   [SMOKE TEST] WS Event Received: DETECTION - ID: ...
+   [SMOKE TEST] WS Event Received: ALERT - ID: ...
+   [SMOKE TEST] Session Status: completed
+   [SMOKE TEST] Verifying database persistence via GET /api/events/?session_id=1e571dbb-2041-419b-a249-14a01c873428
+   [SMOKE TEST] Retrieved 20 events from database.
+   [SMOKE TEST] Received 20 events via WebSocket.
+   ======================================================================
+   VERIFICATION SUMMARY:
+    - API liveness check:                      PASSED
+    - Asynchronous Session initiation:          PASSED
+    - In-process model inference processing:   PASSED (40 frames)
+    - Live event broadcasting (WebSocket):     PASSED (20 events)
+    - Event/Alert persistence (DB):            PASSED (20 events)
+   ======================================================================
+   [SMOKE TEST] SUCCESS: Sprint 3 Integrated System Smoke Path is verified end-to-end!
+   ======================================================================
+   ```
+
+### Manual Verification of Logs and DB
+
+After a successful run, you can inspect the generated logs and DB state to confirm everything is working:
+
+1. **Check Backend Log**:
+   ```bash
+   tail -n 20 data/logs/backend.log
+   ```
+   You should see `session_start_requested`, `session_created`, `session_task_started`, `audit_detection_published`, `audit_alert_triggered`, and `session_task_completed`.
+
+2. **Check Inference Log**:
+   ```bash
+   tail -n 20 data/logs/inference.log
+   ```
+   You should see logs matching the model loading (`inference_session_started`, `inference_runtime_configured`, and `inference_session_completed`).
+
+3. **Check Audit Log**:
+   ```bash
+   cat data/logs/audit.log
+   ```
+   This will contain clean JSON-lines payloads for each generated detection and alert.
+
+4. **Verify Database Records**:
+   Run a direct PostgreSQL query to see the rows inserted into the `events` table:
+   ```bash
+   docker compose exec db psql -U hbr_user -d hbr_db -c "SELECT count(*), event_type FROM events GROUP BY event_type;"
+   ```
+

--- a/docs/integration-devops.md
+++ b/docs/integration-devops.md
@@ -340,7 +340,7 @@ The smoke path tests the following lifecycle:
 2. **Execute the automated smoke script inside the API container**:
    Since the container already installs all required packages (PyTorch, OpenCV, websockets, etc.), the easiest and most reliable way to run the smoke test is inside the `api` container.
    ```bash
-   docker compose exec api python scripts/smoke_test.py
+   docker compose exec api python scripts/integration_smoke_test.py
    ```
 
 3. **Expected Output**:

--- a/scripts/integration_smoke_test.py
+++ b/scripts/integration_smoke_test.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""End-to-end integration smoke test script for Sprint 3.
+
+Verifies the integration chain: source -> inference -> alert/event -> API/WebSocket -> DB.
+Can be executed on the host (if dependencies are present) or within the API container.
+"""
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+# Setup sys.path to find the src package
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT_DIR))
+
+# Try to import crucial dependencies or print run-in-docker instructions
+try:
+    import cv2
+    import httpx
+    import numpy as np
+    import torch
+    import websockets
+except ImportError as e:
+    print(f"[SMOKE TEST] Error: Missing dependency '{e.name}'.")
+    print(
+        "[SMOKE TEST] To run this script, it is highly recommended to "
+        "execute it inside the API container:"
+    )
+    print("  docker compose exec api python scripts/integration_smoke_test.py")
+    sys.exit(1)
+
+# Configuration from environment or defaults
+# When running inside the api container, API is at localhost:8000.
+# The database url is set in the api container env, so the API server accesses it automatically.
+API_URL = os.getenv("API_URL", "http://localhost:8000")
+WS_URL = os.getenv("WS_URL", API_URL.replace("http://", "ws://").replace("https://", "wss://"))
+
+RAW_DATA_DIR = ROOT_DIR / "data" / "raw"
+LOGS_DIR = ROOT_DIR / "data" / "logs"
+CHECKPOINT_DIR = LOGS_DIR / "checkpoints"
+CONFIG_PATH = ROOT_DIR / "configs" / "data_pipeline.yml"
+
+VIDEO_NAME = "smoke_sample.mp4"
+VIDEO_PATH = RAW_DATA_DIR / VIDEO_NAME
+CHECKPOINT_NAME = "dummy_checkpoint.pth"
+CHECKPOINT_PATH = CHECKPOINT_DIR / CHECKPOINT_NAME
+
+# The path sent in the POST request to the API.
+# Inside the container, uvicorn runs at /app, and volumes are mounted to /app.
+CONTAINER_VIDEO_PATH = "/app/data/raw/smoke_sample.mp4"
+CONTAINER_CHECKPOINT_PATH = "/app/data/logs/checkpoints/dummy_checkpoint.pth"
+CONTAINER_CONFIG_PATH = "/app/configs/data_pipeline.yml"
+
+
+def create_dummy_checkpoint() -> None:
+    """Create a dummy PyTorch model checkpoint compatible with DummyBehaviorModel."""
+    from src.models.dummy import DummyBehaviorModel
+    CHECKPOINT_DIR.mkdir(parents=True, exist_ok=True)
+    
+    # 5 classes matches the configs/data_pipeline.yml class_labels count
+    model = DummyBehaviorModel(num_classes=5)
+    checkpoint = {
+        "model_name": "dummy",
+        "model_state_dict": model.state_dict(),
+    }
+    torch.save(checkpoint, CHECKPOINT_PATH)
+    print(f"[SMOKE TEST] Generated dummy checkpoint at: {CHECKPOINT_PATH}")
+
+
+def create_dummy_video() -> None:
+    """Create a dummy 40-frame MP4 video using OpenCV."""
+    RAW_DATA_DIR.mkdir(parents=True, exist_ok=True)
+    
+    # Simple checkerboard/gradient video using OpenCV
+    out = cv2.VideoWriter(
+        str(VIDEO_PATH),
+        cv2.VideoWriter_fourcc(*'mp4v'),
+        10,  # 10 FPS
+        (224, 224)  # matches pipeline.target_resolution [224, 224] in configs
+    )
+    
+    if not out.isOpened():
+        print(
+            "[SMOKE TEST] Error: Could not open VideoWriter. "
+            "Make sure ffmpeg/plugins are installed.",
+            file=sys.stderr
+        )
+        sys.exit(1)
+
+    for i in range(40):
+        frame = np.zeros((224, 224, 3), dtype=np.uint8)
+        # Create a dynamic moving text element to make the frames distinct
+        x_pos = int(10 + i * 3)
+        y_pos = int(50 + i * 2)
+        cv2.putText(
+            frame,
+            f"Frame {i}",
+            (x_pos, y_pos),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.6,
+            (0, 255, 0),
+            2
+        )
+        # Draw a moving square
+        cv2.rectangle(
+            frame,
+            (x_pos + 10, y_pos + 10),
+            (x_pos + 40, y_pos + 40),
+            (0, 0, 255),
+            -1
+        )
+        out.write(frame)
+    out.release()
+    print(f"[SMOKE TEST] Generated dummy video at: {VIDEO_PATH}")
+
+
+async def listen_ws_events(received_events: list[Any], stop_event: asyncio.Event) -> None:
+    """WebSocket listener to verify live streaming of detections and alerts."""
+    uri = f"{WS_URL}/ws/live"
+    print(f"[SMOKE TEST] Connecting to WebSocket: {uri}")
+    try:
+        async with websockets.connect(uri) as websocket:
+            print("[SMOKE TEST] WebSocket connected successfully. Listening for live events...")
+            while not stop_event.is_set():
+                try:
+                    # Read websocket messages with timeout
+                    msg = await asyncio.wait_for(websocket.recv(), timeout=0.5)
+                    event_data = json.loads(msg)
+                    received_events.append(event_data)
+                    print(
+                        f"[SMOKE TEST] WS Event Received: {event_data.get('event_type')} "
+                        f"- ID: {event_data.get('event_id')} "
+                        f"- Camera: {event_data.get('camera_id')}"
+                    )
+                except asyncio.TimeoutError:
+                    continue
+                except websockets.exceptions.ConnectionClosed:
+                    print("[SMOKE TEST] WebSocket connection closed by server.")
+                    break
+    except Exception as e:
+        if not stop_event.is_set():
+            print(f"[SMOKE TEST] WebSocket listener encountered error: {e}", file=sys.stderr)
+
+
+async def check_api_health(client: httpx.AsyncClient) -> bool:
+    """Wait for FastAPI API /health endpoint to be ready."""
+    print(f"[SMOKE TEST] Checking API health at {API_URL}/health...")
+    for _ in range(20):
+        try:
+            response = await client.get(f"{API_URL}/health", timeout=2.0)
+            if response.status_code == 200 and response.json().get("status") == "ok":
+                print("[SMOKE TEST] API is healthy and responding.")
+                return True
+        except Exception:
+            pass
+        await asyncio.sleep(1.0)
+    print("[SMOKE TEST] API did not become healthy in time.", file=sys.stderr)
+    return False
+
+
+async def run_smoke_test() -> None:
+    """Main smoke test orchestration flow."""
+    print("=" * 70)
+    print("STARTING SPRINT 3 INTEGRATION SMOKE TEST")
+    print("=" * 70)
+
+    # 1. Generate local files (will map to /app inside container)
+    create_dummy_checkpoint()
+    create_dummy_video()
+
+    # 2. Setup Async HTTP client and verify API is up
+    async with httpx.AsyncClient() as client:
+        if not await check_api_health(client):
+            print("[SMOKE TEST] Smoke test aborted: API is not healthy.", file=sys.stderr)
+            sys.exit(1)
+
+        # 3. Spin up WebSocket live listener in the background
+        received_events: list[Any] = []
+        stop_ws = asyncio.Event()
+        ws_task = asyncio.create_task(listen_ws_events(received_events, stop_ws))
+        
+        # Give WS a moment to handshake
+        await asyncio.sleep(1.0)
+
+        # 4. Trigger Session creation via POST /api/sessions/
+        session_request = {
+            "video_path": CONTAINER_VIDEO_PATH,
+            "checkpoint_path": CONTAINER_CHECKPOINT_PATH,
+            "config_path": CONTAINER_CONFIG_PATH,
+            "device": "cpu"
+        }
+        
+        print("[SMOKE TEST] Starting session via POST /api/sessions/")
+        try:
+            resp = await client.post(
+                f"{API_URL}/api/sessions/",
+                json=session_request,
+                timeout=5.0
+            )
+        except Exception as e:
+            print(f"[SMOKE TEST] HTTP Request failed: {e}", file=sys.stderr)
+            stop_ws.set()
+            await ws_task
+            sys.exit(1)
+
+        if resp.status_code != 201:
+            print(
+                f"[SMOKE TEST] Session creation failed with status {resp.status_code}: {resp.text}",
+                file=sys.stderr
+            )
+            stop_ws.set()
+            await ws_task
+            sys.exit(1)
+
+        session_data = resp.json()
+        session_id = session_data.get("id")
+        print(f"[SMOKE TEST] Session created successfully. ID: {session_id}")
+
+        # 5. Monitor Session status
+        print("[SMOKE TEST] Monitoring session status...")
+        session_completed = False
+        for _ in range(60):  # Wait up to 60 seconds
+            await asyncio.sleep(1.0)
+            status_resp = await client.get(f"{API_URL}/api/sessions/{session_id}")
+            if status_resp.status_code != 200:
+                print(
+                    f"[SMOKE TEST] Failed to retrieve status: {status_resp.text}",
+                    file=sys.stderr
+                )
+                break
+                
+            status_data = status_resp.json()
+            status = status_data.get("status")
+            print(f"[SMOKE TEST] Session Status: {status}")
+            
+            if status == "completed":
+                session_completed = True
+                break
+            elif status in ("failed", "stopped"):
+                print(
+                    f"[SMOKE TEST] Session terminated early. Status: {status}. "
+                    f"Error: {status_data.get('error')}",
+                    file=sys.stderr
+                )
+                break
+
+        # Stop WebSocket listener
+        await asyncio.sleep(1.0)  # wait a moment for late WS frames
+        stop_ws.set()
+        await ws_task
+
+        if not session_completed:
+            print(
+                "[SMOKE TEST] Smoke test failed: Session did not complete successfully.",
+                file=sys.stderr
+            )
+            sys.exit(1)
+
+        # 6. Verify Database Persistence via REST API GET /api/events/
+        print(
+            f"[SMOKE TEST] Verifying database persistence via "
+            f"GET /api/events/?session_id={session_id}"
+        )
+        try:
+            events_resp = await client.get(
+                f"{API_URL}/api/events/?session_id={session_id}",
+                timeout=5.0
+            )
+        except Exception as e:
+            print(f"[SMOKE TEST] Failed to query persisted events: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        if events_resp.status_code != 200:
+            print(
+                f"[SMOKE TEST] Querying events returned status {events_resp.status_code}: "
+                f"{events_resp.text}",
+                file=sys.stderr
+            )
+            sys.exit(1)
+
+        db_events = events_resp.json()
+        print(f"[SMOKE TEST] Retrieved {len(db_events)} events from database.")
+
+        # 7. Assertions
+        if len(db_events) == 0:
+            print(
+                "[SMOKE TEST] FAILURE: DB is empty. Events were not persisted to database!",
+                file=sys.stderr
+            )
+            sys.exit(1)
+
+        if len(received_events) == 0:
+            print(
+                "[SMOKE TEST] FAILURE: No live events were broadcasted over WebSocket!",
+                file=sys.stderr
+            )
+            sys.exit(1)
+
+        # Verify that both DETECTION and ALERT types are present in DB events
+        db_event_types = {e.get("event_type") for e in db_events}
+        if "DETECTION" not in db_event_types:
+            print(
+                "[SMOKE TEST] FAILURE: No DETECTION events found in persisted database events!",
+                file=sys.stderr
+            )
+            sys.exit(1)
+        if "ALERT" not in db_event_types:
+            print(
+                "[SMOKE TEST] FAILURE: No ALERT events found in persisted database events!",
+                file=sys.stderr
+            )
+            sys.exit(1)
+
+        # Verify that both DETECTION and ALERT types are received over WebSocket
+        ws_event_types = {e.get("event_type") for e in received_events}
+        if "DETECTION" not in ws_event_types:
+            print(
+                "[SMOKE TEST] FAILURE: No DETECTION events received over WebSocket!",
+                file=sys.stderr
+            )
+            sys.exit(1)
+        if "ALERT" not in ws_event_types:
+            print(
+                "[SMOKE TEST] FAILURE: No ALERT events received over WebSocket!",
+                file=sys.stderr
+            )
+            sys.exit(1)
+
+        print("=" * 70)
+        print("VERIFICATION SUMMARY:")
+        print(" - API liveness check:                      PASSED")
+        print(" - Asynchronous Session initiation:          PASSED")
+        print(" - In-process model inference processing:   PASSED (40 frames)")
+        ws_msg = (
+            f" - Live event broadcasting (WebSocket):     "
+            f"PASSED ({len(received_events)} events, including DETECT and ALERT)"
+        )
+        db_msg = (
+            f" - Event/Alert persistence (DB):            "
+            f"PASSED ({len(db_events)} events, including DETECT and ALERT)"
+        )
+        print(ws_msg)
+        print(db_msg)
+        print("=" * 70)
+        print("[SMOKE TEST] SUCCESS: Sprint 3 Integrated System Smoke Path is verified end-to-end!")
+        print("=" * 70)
+
+
+def main() -> None:
+    """Entry point for the smoke test."""
+    try:
+        asyncio.run(run_smoke_test())
+    except KeyboardInterrupt:
+        print("\n[SMOKE TEST] Aborted by user.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -1,322 +1,69 @@
-#!/usr/bin/env python3
-"""End-to-end smoke test script for Sprint 3.
-
-Verifies the integration chain: source -> inference -> alert/event -> API/WebSocket -> DB.
-Can be executed on the host (if dependencies are present) or within the API container.
-"""
-
-import asyncio
-import json
-import os
+import argparse
+import time
 import sys
 from pathlib import Path
-from typing import Any
+import torch
+import yaml
 
-# Setup sys.path to find the src package
-ROOT_DIR = Path(__file__).resolve().parents[1]
-sys.path.append(str(ROOT_DIR))
-
-# Try to import crucial dependencies or print run-in-docker instructions
-try:
-    import cv2
-    import httpx
-    import numpy as np
-    import torch
-    import websockets
-except ImportError as e:
-    print(f"[SMOKE TEST] Error: Missing dependency '{e.name}'.")
-    print(
-        "[SMOKE TEST] To run this script, it is highly recommended to "
-        "execute it inside the API container:"
-    )
-    print("  docker compose exec api python scripts/smoke_test.py")
-    sys.exit(1)
-
-# Configuration from environment or defaults
-# When running inside the api container, API is at localhost:8000.
-# The database url is set in the api container env, so the API server accesses it automatically.
-API_URL = os.getenv("API_URL", "http://localhost:8000")
-WS_URL = os.getenv("WS_URL", API_URL.replace("http://", "ws://").replace("https://", "wss://"))
-
-RAW_DATA_DIR = ROOT_DIR / "data" / "raw"
-LOGS_DIR = ROOT_DIR / "data" / "logs"
-CHECKPOINT_DIR = LOGS_DIR / "checkpoints"
-CONFIG_PATH = ROOT_DIR / "configs" / "data_pipeline.yml"
-
-VIDEO_NAME = "smoke_sample.mp4"
-VIDEO_PATH = RAW_DATA_DIR / VIDEO_NAME
-CHECKPOINT_NAME = "dummy_checkpoint.pth"
-CHECKPOINT_PATH = CHECKPOINT_DIR / CHECKPOINT_NAME
-
-# The path sent in the POST request to the API.
-# Inside the container, uvicorn runs at /app, and volumes are mounted to /app.
-CONTAINER_VIDEO_PATH = "/app/data/raw/smoke_sample.mp4"
-CONTAINER_CHECKPOINT_PATH = "/app/data/logs/checkpoints/dummy_checkpoint.pth"
-CONTAINER_CONFIG_PATH = "/app/configs/data_pipeline.yml"
+from src.data.loader import get_dataloader
+from src.models.baseline import BaselineBehaviorModel
 
 
-def create_dummy_checkpoint() -> None:
-    """Create a dummy PyTorch model checkpoint compatible with DummyBehaviorModel."""
-    from src.models.dummy import DummyBehaviorModel
-    CHECKPOINT_DIR.mkdir(parents=True, exist_ok=True)
-    
-    # 5 classes matches the configs/data_pipeline.yml class_labels count
-    model = DummyBehaviorModel(num_classes=5)
-    checkpoint = {
-        "model_name": "dummy",
-        "model_state_dict": model.state_dict(),
-    }
-    torch.save(checkpoint, CHECKPOINT_PATH)
-    print(f"[SMOKE TEST] Generated dummy checkpoint at: {CHECKPOINT_PATH}")
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", default="configs/data_pipeline.yml")
+    parser.add_argument("--batches", type=int, default=3, help="Number of batches to test")
+    args = parser.parse_args()
 
+    with open(args.config, "r") as f:
+        config = yaml.safe_load(f)
 
-def create_dummy_video() -> None:
-    """Create a dummy 40-frame MP4 video using OpenCV."""
-    RAW_DATA_DIR.mkdir(parents=True, exist_ok=True)
-    
-    # Simple checkerboard/gradient video using OpenCV
-    out = cv2.VideoWriter(
-        str(VIDEO_PATH),
-        cv2.VideoWriter_fourcc(*'mp4v'),
-        10,  # 10 FPS
-        (224, 224)  # matches pipeline.target_resolution [224, 224] in configs
-    )
-    
-    if not out.isOpened():
-        print(
-            "[SMOKE TEST] Error: Could not open VideoWriter. "
-            "Make sure ffmpeg/plugins are installed.",
-            file=sys.stderr
-        )
+    manifest_path = Path(config["directories"]["manifests"]) / "manifest.jsonl"
+    raw_dir = Path(config["directories"]["raw"])
+
+    if not manifest_path.exists():
+        print(f"[ERROR] Manifest not found at {manifest_path}. Run src.data.sample first.")
         sys.exit(1)
 
-    for i in range(40):
-        frame = np.zeros((224, 224, 3), dtype=np.uint8)
-        # Create a dynamic moving text element to make the frames distinct
-        x_pos = int(10 + i * 3)
-        y_pos = int(50 + i * 2)
-        cv2.putText(
-            frame,
-            f"Frame {i}",
-            (x_pos, y_pos),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            0.6,
-            (0, 255, 0),
-            2
-        )
-        # Draw a moving square
-        cv2.rectangle(
-            frame,
-            (x_pos + 10, y_pos + 10),
-            (x_pos + 40, y_pos + 40),
-            (0, 0, 255),
-            -1
-        )
-        out.write(frame)
-    out.release()
-    print(f"[SMOKE TEST] Generated dummy video at: {VIDEO_PATH}")
+    print("--- Starting Smoke Test ---")
+    start_time = time.time()
 
+    loader = get_dataloader(
+        manifest_path=manifest_path,
+        data_dir=raw_dir,
+        split="train",
+        batch_size=2,
+        config_path=Path(args.config)
+    )
 
-async def listen_ws_events(received_events: list[Any], stop_event: asyncio.Event) -> None:
-    """WebSocket listener to verify live streaming of detections and alerts."""
-    uri = f"{WS_URL}/ws/live"
-    print(f"[SMOKE TEST] Connecting to WebSocket: {uri}")
+    num_classes = len(loader.dataset.label_to_idx)
+    model = BaselineBehaviorModel(num_classes=num_classes)
+    model.eval()
+
+    print(f"Detected {num_classes} classes in manifest.")
+    print(f"Processing {args.batches} batches...")
+
     try:
-        async with websockets.connect(uri) as websocket:
-            print("[SMOKE TEST] WebSocket connected successfully. Listening for live events...")
-            while not stop_event.is_set():
-                try:
-                    # Read websocket messages with timeout
-                    msg = await asyncio.wait_for(websocket.recv(), timeout=0.5)
-                    event_data = json.loads(msg)
-                    received_events.append(event_data)
-                    print(
-                        f"[SMOKE TEST] WS Event Received: {event_data.get('event_type')} "
-                        f"- ID: {event_data.get('event_id')} "
-                        f"- Camera: {event_data.get('camera_id')}"
-                    )
-                except asyncio.TimeoutError:
-                    continue
-                except websockets.exceptions.ConnectionClosed:
-                    print("[SMOKE TEST] WebSocket connection closed by server.")
-                    break
+        for i, (videos, labels) in enumerate(loader):
+            if i >= args.batches:
+                break
+
+            with torch.no_grad():
+                outputs = model(videos)
+
+            print(f"Batch {i + 1}:")
+            print(f"  - Input shape:  {list(videos.shape)} [B, T, C, H, W]")
+            print(f"  - Output shape: {list(outputs.shape)} [B, num_classes]")
+            print(f"  - Labels:       {labels.tolist()}")
+
+        elapsed = time.time() - start_time
+        print("\n--- SUCCESS ---")
+        print(f"Timing: {elapsed:.2f}s total ({elapsed / args.batches:.2f}s per batch)")
+        sys.exit(0)
+
     except Exception as e:
-        if not stop_event.is_set():
-            print(f"[SMOKE TEST] WebSocket listener encountered error: {e}", file=sys.stderr)
-
-
-async def check_api_health(client: httpx.AsyncClient) -> bool:
-    """Wait for FastAPI API /health endpoint to be ready."""
-    print(f"[SMOKE TEST] Checking API health at {API_URL}/health...")
-    for _ in range(20):
-        try:
-            response = await client.get(f"{API_URL}/health", timeout=2.0)
-            if response.status_code == 200 and response.json().get("status") == "ok":
-                print("[SMOKE TEST] API is healthy and responding.")
-                return True
-        except Exception:
-            pass
-        await asyncio.sleep(1.0)
-    print("[SMOKE TEST] API did not become healthy in time.", file=sys.stderr)
-    return False
-
-
-async def run_smoke_test() -> None:
-    """Main smoke test orchestration flow."""
-    print("=" * 70)
-    print("STARTING SPRINT 3 INTEGRATION SMOKE TEST")
-    print("=" * 70)
-
-    # 1. Generate local files (will map to /app inside container)
-    create_dummy_checkpoint()
-    create_dummy_video()
-
-    # 2. Setup Async HTTP client and verify API is up
-    async with httpx.AsyncClient() as client:
-        if not await check_api_health(client):
-            print("[SMOKE TEST] Smoke test aborted: API is not healthy.", file=sys.stderr)
-            sys.exit(1)
-
-        # 3. Spin up WebSocket live listener in the background
-        received_events: list[Any] = []
-        stop_ws = asyncio.Event()
-        ws_task = asyncio.create_task(listen_ws_events(received_events, stop_ws))
-        
-        # Give WS a moment to handshake
-        await asyncio.sleep(1.0)
-
-        # 4. Trigger Session creation via POST /api/sessions/
-        session_request = {
-            "video_path": CONTAINER_VIDEO_PATH,
-            "checkpoint_path": CONTAINER_CHECKPOINT_PATH,
-            "config_path": CONTAINER_CONFIG_PATH,
-            "device": "cpu"
-        }
-        
-        print("[SMOKE TEST] Starting session via POST /api/sessions/")
-        try:
-            resp = await client.post(
-                f"{API_URL}/api/sessions/",
-                json=session_request,
-                timeout=5.0
-            )
-        except Exception as e:
-            print(f"[SMOKE TEST] HTTP Request failed: {e}", file=sys.stderr)
-            stop_ws.set()
-            await ws_task
-            sys.exit(1)
-
-        if resp.status_code != 201:
-            print(
-                f"[SMOKE TEST] Session creation failed with status {resp.status_code}: {resp.text}",
-                file=sys.stderr
-            )
-            stop_ws.set()
-            await ws_task
-            sys.exit(1)
-
-        session_data = resp.json()
-        session_id = session_data.get("id")
-        print(f"[SMOKE TEST] Session created successfully. ID: {session_id}")
-
-        # 5. Monitor Session status
-        print("[SMOKE TEST] Monitoring session status...")
-        session_completed = False
-        for _ in range(60):  # Wait up to 60 seconds
-            await asyncio.sleep(1.0)
-            status_resp = await client.get(f"{API_URL}/api/sessions/{session_id}")
-            if status_resp.status_code != 200:
-                print(
-                    f"[SMOKE TEST] Failed to retrieve status: {status_resp.text}",
-                    file=sys.stderr
-                )
-                break
-                
-            status_data = status_resp.json()
-            status = status_data.get("status")
-            print(f"[SMOKE TEST] Session Status: {status}")
-            
-            if status == "completed":
-                session_completed = True
-                break
-            elif status in ("failed", "stopped"):
-                print(
-                    f"[SMOKE TEST] Session terminated early. Status: {status}. "
-                    f"Error: {status_data.get('error')}",
-                    file=sys.stderr
-                )
-                break
-
-        # Stop WebSocket listener
-        await asyncio.sleep(1.0)  # wait a moment for late WS frames
-        stop_ws.set()
-        await ws_task
-
-        if not session_completed:
-            print(
-                "[SMOKE TEST] Smoke test failed: Session did not complete successfully.",
-                file=sys.stderr
-            )
-            sys.exit(1)
-
-        # 6. Verify Database Persistence via REST API GET /api/events/
-        print(
-            f"[SMOKE TEST] Verifying database persistence via "
-            f"GET /api/events/?session_id={session_id}"
-        )
-        try:
-            events_resp = await client.get(
-                f"{API_URL}/api/events/?session_id={session_id}",
-                timeout=5.0
-            )
-        except Exception as e:
-            print(f"[SMOKE TEST] Failed to query persisted events: {e}", file=sys.stderr)
-            sys.exit(1)
-
-        if events_resp.status_code != 200:
-            print(
-                f"[SMOKE TEST] Querying events returned status {events_resp.status_code}: "
-                f"{events_resp.text}",
-                file=sys.stderr
-            )
-            sys.exit(1)
-
-        db_events = events_resp.json()
-        print(f"[SMOKE TEST] Retrieved {len(db_events)} events from database.")
-
-        # 7. Assertions
-        if len(db_events) == 0:
-            print(
-                "[SMOKE TEST] FAILURE: DB is empty. Events were not persisted to database!",
-                file=sys.stderr
-            )
-            sys.exit(1)
-
-        if len(received_events) == 0:
-            print(
-                "[SMOKE TEST] FAILURE: No live events were broadcasted over WebSocket!",
-                file=sys.stderr
-            )
-            sys.exit(1)
-
-        print("=" * 70)
-        print("VERIFICATION SUMMARY:")
-        print(" - API liveness check:                      PASSED")
-        print(" - Asynchronous Session initiation:          PASSED")
-        print(" - In-process model inference processing:   PASSED (40 frames)")
-        print(f" - Live event broadcasting (WebSocket):     PASSED ({len(received_events)} events)")
-        print(f" - Event/Alert persistence (DB):            PASSED ({len(db_events)} events)")
-        print("=" * 70)
-        print("[SMOKE TEST] SUCCESS: Sprint 3 Integrated System Smoke Path is verified end-to-end!")
-        print("=" * 70)
-
-
-def main() -> None:
-    """Entry point for the smoke test."""
-    try:
-        asyncio.run(run_smoke_test())
-    except KeyboardInterrupt:
-        print("\n[SMOKE TEST] Aborted by user.")
+        print("\n--- FAILED ---")
+        print(f"Error: {str(e)}")
         sys.exit(1)
 
 

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
-"""
-End-to-end smoke test script for Sprint 3.
+"""End-to-end smoke test script for Sprint 3.
+
 Verifies the integration chain: source -> inference -> alert/event -> API/WebSocket -> DB.
 Can be executed on the host (if dependencies are present) or within the API container.
 """
 
 import asyncio
+import json
 import os
 import sys
 from pathlib import Path
-import json
+from typing import Any
 
 # Setup sys.path to find the src package
 ROOT_DIR = Path(__file__).resolve().parents[1]
@@ -17,14 +18,17 @@ sys.path.append(str(ROOT_DIR))
 
 # Try to import crucial dependencies or print run-in-docker instructions
 try:
-    import torch
-    import numpy as np
     import cv2
     import httpx
+    import numpy as np
+    import torch
     import websockets
 except ImportError as e:
     print(f"[SMOKE TEST] Error: Missing dependency '{e.name}'.")
-    print("[SMOKE TEST] To run this script, it is highly recommended to execute it inside the API container:")
+    print(
+        "[SMOKE TEST] To run this script, it is highly recommended to "
+        "execute it inside the API container:"
+    )
     print("  docker compose exec api python scripts/smoke_test.py")
     sys.exit(1)
 
@@ -51,7 +55,7 @@ CONTAINER_CHECKPOINT_PATH = "/app/data/logs/checkpoints/dummy_checkpoint.pth"
 CONTAINER_CONFIG_PATH = "/app/configs/data_pipeline.yml"
 
 
-def create_dummy_checkpoint():
+def create_dummy_checkpoint() -> None:
     """Create a dummy PyTorch model checkpoint compatible with DummyBehaviorModel."""
     from src.models.dummy import DummyBehaviorModel
     CHECKPOINT_DIR.mkdir(parents=True, exist_ok=True)
@@ -66,7 +70,7 @@ def create_dummy_checkpoint():
     print(f"[SMOKE TEST] Generated dummy checkpoint at: {CHECKPOINT_PATH}")
 
 
-def create_dummy_video():
+def create_dummy_video() -> None:
     """Create a dummy 40-frame MP4 video using OpenCV."""
     RAW_DATA_DIR.mkdir(parents=True, exist_ok=True)
     
@@ -79,7 +83,11 @@ def create_dummy_video():
     )
     
     if not out.isOpened():
-        print("[SMOKE TEST] Error: Could not open VideoWriter. Make sure ffmpeg/plugins are installed.", file=sys.stderr)
+        print(
+            "[SMOKE TEST] Error: Could not open VideoWriter. "
+            "Make sure ffmpeg/plugins are installed.",
+            file=sys.stderr
+        )
         sys.exit(1)
 
     for i in range(40):
@@ -109,7 +117,7 @@ def create_dummy_video():
     print(f"[SMOKE TEST] Generated dummy video at: {VIDEO_PATH}")
 
 
-async def listen_ws_events(received_events: list, stop_event: asyncio.Event):
+async def listen_ws_events(received_events: list[Any], stop_event: asyncio.Event) -> None:
     """WebSocket listener to verify live streaming of detections and alerts."""
     uri = f"{WS_URL}/ws/live"
     print(f"[SMOKE TEST] Connecting to WebSocket: {uri}")
@@ -140,7 +148,7 @@ async def listen_ws_events(received_events: list, stop_event: asyncio.Event):
 async def check_api_health(client: httpx.AsyncClient) -> bool:
     """Wait for FastAPI API /health endpoint to be ready."""
     print(f"[SMOKE TEST] Checking API health at {API_URL}/health...")
-    for attempt in range(20):
+    for _ in range(20):
         try:
             response = await client.get(f"{API_URL}/health", timeout=2.0)
             if response.status_code == 200 and response.json().get("status") == "ok":
@@ -153,7 +161,7 @@ async def check_api_health(client: httpx.AsyncClient) -> bool:
     return False
 
 
-async def run_smoke_test():
+async def run_smoke_test() -> None:
     """Main smoke test orchestration flow."""
     print("=" * 70)
     print("STARTING SPRINT 3 INTEGRATION SMOKE TEST")
@@ -170,7 +178,7 @@ async def run_smoke_test():
             sys.exit(1)
 
         # 3. Spin up WebSocket live listener in the background
-        received_events = []
+        received_events: list[Any] = []
         stop_ws = asyncio.Event()
         ws_task = asyncio.create_task(listen_ws_events(received_events, stop_ws))
         
@@ -185,9 +193,13 @@ async def run_smoke_test():
             "device": "cpu"
         }
         
-        print(f"[SMOKE TEST] Starting session via POST /api/sessions/")
+        print("[SMOKE TEST] Starting session via POST /api/sessions/")
         try:
-            resp = await client.post(f"{API_URL}/api/sessions/", json=session_request, timeout=5.0)
+            resp = await client.post(
+                f"{API_URL}/api/sessions/",
+                json=session_request,
+                timeout=5.0
+            )
         except Exception as e:
             print(f"[SMOKE TEST] HTTP Request failed: {e}", file=sys.stderr)
             stop_ws.set()
@@ -195,7 +207,10 @@ async def run_smoke_test():
             sys.exit(1)
 
         if resp.status_code != 201:
-            print(f"[SMOKE TEST] Session creation failed with status {resp.status_code}: {resp.text}", file=sys.stderr)
+            print(
+                f"[SMOKE TEST] Session creation failed with status {resp.status_code}: {resp.text}",
+                file=sys.stderr
+            )
             stop_ws.set()
             await ws_task
             sys.exit(1)
@@ -205,13 +220,16 @@ async def run_smoke_test():
         print(f"[SMOKE TEST] Session created successfully. ID: {session_id}")
 
         # 5. Monitor Session status
-        print(f"[SMOKE TEST] Monitoring session status...")
+        print("[SMOKE TEST] Monitoring session status...")
         session_completed = False
         for _ in range(60):  # Wait up to 60 seconds
             await asyncio.sleep(1.0)
             status_resp = await client.get(f"{API_URL}/api/sessions/{session_id}")
             if status_resp.status_code != 200:
-                print(f"[SMOKE TEST] Failed to retrieve status: {status_resp.text}", file=sys.stderr)
+                print(
+                    f"[SMOKE TEST] Failed to retrieve status: {status_resp.text}",
+                    file=sys.stderr
+                )
                 break
                 
             status_data = status_resp.json()
@@ -222,7 +240,11 @@ async def run_smoke_test():
                 session_completed = True
                 break
             elif status in ("failed", "stopped"):
-                print(f"[SMOKE TEST] Session terminated early. Status: {status}. Error: {status_data.get('error')}", file=sys.stderr)
+                print(
+                    f"[SMOKE TEST] Session terminated early. Status: {status}. "
+                    f"Error: {status_data.get('error')}",
+                    file=sys.stderr
+                )
                 break
 
         # Stop WebSocket listener
@@ -231,19 +253,32 @@ async def run_smoke_test():
         await ws_task
 
         if not session_completed:
-            print("[SMOKE TEST] Smoke test failed: Session did not complete successfully.", file=sys.stderr)
+            print(
+                "[SMOKE TEST] Smoke test failed: Session did not complete successfully.",
+                file=sys.stderr
+            )
             sys.exit(1)
 
         # 6. Verify Database Persistence via REST API GET /api/events/
-        print(f"[SMOKE TEST] Verifying database persistence via GET /api/events/?session_id={session_id}")
+        print(
+            f"[SMOKE TEST] Verifying database persistence via "
+            f"GET /api/events/?session_id={session_id}"
+        )
         try:
-            events_resp = await client.get(f"{API_URL}/api/events/?session_id={session_id}", timeout=5.0)
+            events_resp = await client.get(
+                f"{API_URL}/api/events/?session_id={session_id}",
+                timeout=5.0
+            )
         except Exception as e:
             print(f"[SMOKE TEST] Failed to query persisted events: {e}", file=sys.stderr)
             sys.exit(1)
 
         if events_resp.status_code != 200:
-            print(f"[SMOKE TEST] Querying events returned status {events_resp.status_code}: {events_resp.text}", file=sys.stderr)
+            print(
+                f"[SMOKE TEST] Querying events returned status {events_resp.status_code}: "
+                f"{events_resp.text}",
+                file=sys.stderr
+            )
             sys.exit(1)
 
         db_events = events_resp.json()
@@ -251,18 +286,24 @@ async def run_smoke_test():
 
         # 7. Assertions
         if len(db_events) == 0:
-            print("[SMOKE TEST] FAILURE: DB is empty. Events were not persisted to database!", file=sys.stderr)
+            print(
+                "[SMOKE TEST] FAILURE: DB is empty. Events were not persisted to database!",
+                file=sys.stderr
+            )
             sys.exit(1)
 
         if len(received_events) == 0:
-            print("[SMOKE TEST] FAILURE: No live events were broadcasted over WebSocket!", file=sys.stderr)
+            print(
+                "[SMOKE TEST] FAILURE: No live events were broadcasted over WebSocket!",
+                file=sys.stderr
+            )
             sys.exit(1)
 
         print("=" * 70)
         print("VERIFICATION SUMMARY:")
-        print(f" - API liveness check:                      PASSED")
-        print(f" - Asynchronous Session initiation:          PASSED")
-        print(f" - In-process model inference processing:   PASSED (40 frames)")
+        print(" - API liveness check:                      PASSED")
+        print(" - Asynchronous Session initiation:          PASSED")
+        print(" - In-process model inference processing:   PASSED (40 frames)")
         print(f" - Live event broadcasting (WebSocket):     PASSED ({len(received_events)} events)")
         print(f" - Event/Alert persistence (DB):            PASSED ({len(db_events)} events)")
         print("=" * 70)
@@ -270,9 +311,14 @@ async def run_smoke_test():
         print("=" * 70)
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Entry point for the smoke test."""
     try:
         asyncio.run(run_smoke_test())
     except KeyboardInterrupt:
         print("\n[SMOKE TEST] Aborted by user.")
         sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -1,71 +1,278 @@
-import argparse
-import time
+#!/usr/bin/env python3
+"""
+End-to-end smoke test script for Sprint 3.
+Verifies the integration chain: source -> inference -> alert/event -> API/WebSocket -> DB.
+Can be executed on the host (if dependencies are present) or within the API container.
+"""
+
+import asyncio
+import os
 import sys
 from pathlib import Path
-import torch
-import yaml
+import json
 
-from src.data.loader import get_dataloader
-from src.models.baseline import BaselineBehaviorModel
+# Setup sys.path to find the src package
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT_DIR))
+
+# Try to import crucial dependencies or print run-in-docker instructions
+try:
+    import torch
+    import numpy as np
+    import cv2
+    import httpx
+    import websockets
+except ImportError as e:
+    print(f"[SMOKE TEST] Error: Missing dependency '{e.name}'.")
+    print("[SMOKE TEST] To run this script, it is highly recommended to execute it inside the API container:")
+    print("  docker compose exec api python scripts/smoke_test.py")
+    sys.exit(1)
+
+# Configuration from environment or defaults
+# When running inside the api container, API is at localhost:8000.
+# The database url is set in the api container env, so the API server accesses it automatically.
+API_URL = os.getenv("API_URL", "http://localhost:8000")
+WS_URL = os.getenv("WS_URL", API_URL.replace("http://", "ws://").replace("https://", "wss://"))
+
+RAW_DATA_DIR = ROOT_DIR / "data" / "raw"
+LOGS_DIR = ROOT_DIR / "data" / "logs"
+CHECKPOINT_DIR = LOGS_DIR / "checkpoints"
+CONFIG_PATH = ROOT_DIR / "configs" / "data_pipeline.yml"
+
+VIDEO_NAME = "smoke_sample.mp4"
+VIDEO_PATH = RAW_DATA_DIR / VIDEO_NAME
+CHECKPOINT_NAME = "dummy_checkpoint.pth"
+CHECKPOINT_PATH = CHECKPOINT_DIR / CHECKPOINT_NAME
+
+# The path sent in the POST request to the API.
+# Inside the container, uvicorn runs at /app, and volumes are mounted to /app.
+CONTAINER_VIDEO_PATH = "/app/data/raw/smoke_sample.mp4"
+CONTAINER_CHECKPOINT_PATH = "/app/data/logs/checkpoints/dummy_checkpoint.pth"
+CONTAINER_CONFIG_PATH = "/app/configs/data_pipeline.yml"
 
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--config", default="configs/data_pipeline.yml")
-    parser.add_argument("--batches", type=int, default=3, help="Number of batches to test")
-    args = parser.parse_args()
+def create_dummy_checkpoint():
+    """Create a dummy PyTorch model checkpoint compatible with DummyBehaviorModel."""
+    from src.models.dummy import DummyBehaviorModel
+    CHECKPOINT_DIR.mkdir(parents=True, exist_ok=True)
+    
+    # 5 classes matches the configs/data_pipeline.yml class_labels count
+    model = DummyBehaviorModel(num_classes=5)
+    checkpoint = {
+        "model_name": "dummy",
+        "model_state_dict": model.state_dict(),
+    }
+    torch.save(checkpoint, CHECKPOINT_PATH)
+    print(f"[SMOKE TEST] Generated dummy checkpoint at: {CHECKPOINT_PATH}")
 
-    with open(args.config, "r") as f:
-        config = yaml.safe_load(f)
 
-    manifest_path = Path(config["directories"]["manifests"]) / "manifest.jsonl"
-    raw_dir = Path(config["directories"]["raw"])
-
-    if not manifest_path.exists():
-        print(f"[ERROR] Manifest not found at {manifest_path}. Run src.data.sample first.")
+def create_dummy_video():
+    """Create a dummy 40-frame MP4 video using OpenCV."""
+    RAW_DATA_DIR.mkdir(parents=True, exist_ok=True)
+    
+    # Simple checkerboard/gradient video using OpenCV
+    out = cv2.VideoWriter(
+        str(VIDEO_PATH),
+        cv2.VideoWriter_fourcc(*'mp4v'),
+        10,  # 10 FPS
+        (224, 224)  # matches pipeline.target_resolution [224, 224] in configs
+    )
+    
+    if not out.isOpened():
+        print("[SMOKE TEST] Error: Could not open VideoWriter. Make sure ffmpeg/plugins are installed.", file=sys.stderr)
         sys.exit(1)
 
-    print("--- Starting Smoke Test ---")
-    start_time = time.time()
+    for i in range(40):
+        frame = np.zeros((224, 224, 3), dtype=np.uint8)
+        # Create a dynamic moving text element to make the frames distinct
+        x_pos = int(10 + i * 3)
+        y_pos = int(50 + i * 2)
+        cv2.putText(
+            frame,
+            f"Frame {i}",
+            (x_pos, y_pos),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.6,
+            (0, 255, 0),
+            2
+        )
+        # Draw a moving square
+        cv2.rectangle(
+            frame,
+            (x_pos + 10, y_pos + 10),
+            (x_pos + 40, y_pos + 40),
+            (0, 0, 255),
+            -1
+        )
+        out.write(frame)
+    out.release()
+    print(f"[SMOKE TEST] Generated dummy video at: {VIDEO_PATH}")
 
-    loader = get_dataloader(
-        manifest_path=manifest_path,
-        data_dir=raw_dir,
-        split="train",
-        batch_size=2,
-        config_path=Path(args.config)
-    )
 
-    num_classes = len(loader.dataset.label_to_idx)
-    model = BaselineBehaviorModel(num_classes=num_classes)
-    model.eval()
-
-    print(f"Detected {num_classes} classes in manifest.")
-    print(f"Processing {args.batches} batches...")
-
+async def listen_ws_events(received_events: list, stop_event: asyncio.Event):
+    """WebSocket listener to verify live streaming of detections and alerts."""
+    uri = f"{WS_URL}/ws/live"
+    print(f"[SMOKE TEST] Connecting to WebSocket: {uri}")
     try:
-        for i, (videos, labels) in enumerate(loader):
-            if i >= args.batches:
+        async with websockets.connect(uri) as websocket:
+            print("[SMOKE TEST] WebSocket connected successfully. Listening for live events...")
+            while not stop_event.is_set():
+                try:
+                    # Read websocket messages with timeout
+                    msg = await asyncio.wait_for(websocket.recv(), timeout=0.5)
+                    event_data = json.loads(msg)
+                    received_events.append(event_data)
+                    print(
+                        f"[SMOKE TEST] WS Event Received: {event_data.get('event_type')} "
+                        f"- ID: {event_data.get('event_id')} "
+                        f"- Camera: {event_data.get('camera_id')}"
+                    )
+                except asyncio.TimeoutError:
+                    continue
+                except websockets.exceptions.ConnectionClosed:
+                    print("[SMOKE TEST] WebSocket connection closed by server.")
+                    break
+    except Exception as e:
+        if not stop_event.is_set():
+            print(f"[SMOKE TEST] WebSocket listener encountered error: {e}", file=sys.stderr)
+
+
+async def check_api_health(client: httpx.AsyncClient) -> bool:
+    """Wait for FastAPI API /health endpoint to be ready."""
+    print(f"[SMOKE TEST] Checking API health at {API_URL}/health...")
+    for attempt in range(20):
+        try:
+            response = await client.get(f"{API_URL}/health", timeout=2.0)
+            if response.status_code == 200 and response.json().get("status") == "ok":
+                print("[SMOKE TEST] API is healthy and responding.")
+                return True
+        except Exception:
+            pass
+        await asyncio.sleep(1.0)
+    print("[SMOKE TEST] API did not become healthy in time.", file=sys.stderr)
+    return False
+
+
+async def run_smoke_test():
+    """Main smoke test orchestration flow."""
+    print("=" * 70)
+    print("STARTING SPRINT 3 INTEGRATION SMOKE TEST")
+    print("=" * 70)
+
+    # 1. Generate local files (will map to /app inside container)
+    create_dummy_checkpoint()
+    create_dummy_video()
+
+    # 2. Setup Async HTTP client and verify API is up
+    async with httpx.AsyncClient() as client:
+        if not await check_api_health(client):
+            print("[SMOKE TEST] Smoke test aborted: API is not healthy.", file=sys.stderr)
+            sys.exit(1)
+
+        # 3. Spin up WebSocket live listener in the background
+        received_events = []
+        stop_ws = asyncio.Event()
+        ws_task = asyncio.create_task(listen_ws_events(received_events, stop_ws))
+        
+        # Give WS a moment to handshake
+        await asyncio.sleep(1.0)
+
+        # 4. Trigger Session creation via POST /api/sessions/
+        session_request = {
+            "video_path": CONTAINER_VIDEO_PATH,
+            "checkpoint_path": CONTAINER_CHECKPOINT_PATH,
+            "config_path": CONTAINER_CONFIG_PATH,
+            "device": "cpu"
+        }
+        
+        print(f"[SMOKE TEST] Starting session via POST /api/sessions/")
+        try:
+            resp = await client.post(f"{API_URL}/api/sessions/", json=session_request, timeout=5.0)
+        except Exception as e:
+            print(f"[SMOKE TEST] HTTP Request failed: {e}", file=sys.stderr)
+            stop_ws.set()
+            await ws_task
+            sys.exit(1)
+
+        if resp.status_code != 201:
+            print(f"[SMOKE TEST] Session creation failed with status {resp.status_code}: {resp.text}", file=sys.stderr)
+            stop_ws.set()
+            await ws_task
+            sys.exit(1)
+
+        session_data = resp.json()
+        session_id = session_data.get("id")
+        print(f"[SMOKE TEST] Session created successfully. ID: {session_id}")
+
+        # 5. Monitor Session status
+        print(f"[SMOKE TEST] Monitoring session status...")
+        session_completed = False
+        for _ in range(60):  # Wait up to 60 seconds
+            await asyncio.sleep(1.0)
+            status_resp = await client.get(f"{API_URL}/api/sessions/{session_id}")
+            if status_resp.status_code != 200:
+                print(f"[SMOKE TEST] Failed to retrieve status: {status_resp.text}", file=sys.stderr)
+                break
+                
+            status_data = status_resp.json()
+            status = status_data.get("status")
+            print(f"[SMOKE TEST] Session Status: {status}")
+            
+            if status == "completed":
+                session_completed = True
+                break
+            elif status in ("failed", "stopped"):
+                print(f"[SMOKE TEST] Session terminated early. Status: {status}. Error: {status_data.get('error')}", file=sys.stderr)
                 break
 
-            with torch.no_grad():
-                outputs = model(videos)
+        # Stop WebSocket listener
+        await asyncio.sleep(1.0)  # wait a moment for late WS frames
+        stop_ws.set()
+        await ws_task
 
-            print(f"Batch {i + 1}:")
-            print(f"  - Input shape:  {list(videos.shape)} [B, T, C, H, W]")
-            print(f"  - Output shape: {list(outputs.shape)} [B, num_classes]")
-            print(f"  - Labels:       {labels.tolist()}")
+        if not session_completed:
+            print("[SMOKE TEST] Smoke test failed: Session did not complete successfully.", file=sys.stderr)
+            sys.exit(1)
 
-        elapsed = time.time() - start_time
-        print("\n--- SUCCESS ---")
-        print(f"Timing: {elapsed:.2f}s total ({elapsed / args.batches:.2f}s per batch)")
-        sys.exit(0)
+        # 6. Verify Database Persistence via REST API GET /api/events/
+        print(f"[SMOKE TEST] Verifying database persistence via GET /api/events/?session_id={session_id}")
+        try:
+            events_resp = await client.get(f"{API_URL}/api/events/?session_id={session_id}", timeout=5.0)
+        except Exception as e:
+            print(f"[SMOKE TEST] Failed to query persisted events: {e}", file=sys.stderr)
+            sys.exit(1)
 
-    except Exception as e:
-        print("\n--- FAILED ---")
-        print(f"Error: {str(e)}")
-        sys.exit(1)
+        if events_resp.status_code != 200:
+            print(f"[SMOKE TEST] Querying events returned status {events_resp.status_code}: {events_resp.text}", file=sys.stderr)
+            sys.exit(1)
+
+        db_events = events_resp.json()
+        print(f"[SMOKE TEST] Retrieved {len(db_events)} events from database.")
+
+        # 7. Assertions
+        if len(db_events) == 0:
+            print("[SMOKE TEST] FAILURE: DB is empty. Events were not persisted to database!", file=sys.stderr)
+            sys.exit(1)
+
+        if len(received_events) == 0:
+            print("[SMOKE TEST] FAILURE: No live events were broadcasted over WebSocket!", file=sys.stderr)
+            sys.exit(1)
+
+        print("=" * 70)
+        print("VERIFICATION SUMMARY:")
+        print(f" - API liveness check:                      PASSED")
+        print(f" - Asynchronous Session initiation:          PASSED")
+        print(f" - In-process model inference processing:   PASSED (40 frames)")
+        print(f" - Live event broadcasting (WebSocket):     PASSED ({len(received_events)} events)")
+        print(f" - Event/Alert persistence (DB):            PASSED ({len(db_events)} events)")
+        print("=" * 70)
+        print("[SMOKE TEST] SUCCESS: Sprint 3 Integrated System Smoke Path is verified end-to-end!")
+        print("=" * 70)
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        asyncio.run(run_smoke_test())
+    except KeyboardInterrupt:
+        print("\n[SMOKE TEST] Aborted by user.")
+        sys.exit(1)


### PR DESCRIPTION
Closes #88 
## Summary

Add one minimal but reliable end-to-end smoke path for the integrated Sprint 3 system so the team can verify the whole chain after `docker-compose up`.

## Scope & Changes
This PR introduces the following changes:
1. **Automated Smoke Test (`scripts/smoke_test.py`)**:
   - Automatically sets up required directories and constructs a dummy model checkpoint `.pth` file using `DummyBehaviorModel`.
   - Generates a dummy 40-frame video file (`smoke_sample.mp4`) using OpenCV.
   - Waits for the FastAPI API `/health` endpoint to be ready.
   - Subscribes to the live WebSocket endpoint (`ws://localhost:8000/ws/live`).
   - Launches an offline inference session via a `POST /api/sessions/` request.
   - Listens to incoming detections and alerts broadcasted over WebSockets.
   - Queries the REST API `GET /api/events/?session_id=<id>` to verify PostgreSQL database persistence.
2. **Integration & DevOps Docs (`docs/integration-devops.md`)**:
   - Added a new section documenting the integration chain flow, step-by-step run instructions, expected terminal logs, and troubleshooting steps.
3. **Readme Quick Start (`README.md`)**:
   - Added the quick check command to run the integration smoke test under the backend/session section.
