### PR TITLE
129 feature align mp4 and rtsp sessions with shared runtime event contract

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -245,7 +245,7 @@ To support context-aware alerting in Sprint 3, a lightweight **Context Module** 
 - **Performance:** Deterministic output confirmed via local verification tests (`tests/inference/test_context.py`).
 
 ### Output Contract
-The `ContextModule` enriches inference with scene-level context metadata. All paths (browser camera, RTSP, and MP4) now utilize the unified `InferenceEventPipeline` which guarantees that the nested `context` object is included in every serialized event in `actions.json` (as part of `ActionEvent` payloads):
+The `ContextModule` enriches inference with scene-level context metadata. All paths (browser camera, RTSP, and MP4) now utilize the unified `InferenceEventPipeline`; when context evaluation is enabled and produces a non-`unknown` scene tag, the nested `context` object is populated on emitted `ActionEvent`s (and serialized into `actions.json`).
 
 ```json
 "context": {

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -245,9 +245,7 @@ To support context-aware alerting in Sprint 3, a lightweight **Context Module** 
 - **Performance:** Deterministic output confirmed via local verification tests (`tests/inference/test_context.py`).
 
 ### Output Contract
-The `ContextModule` enriches inference with scene-level context metadata, but the current `actions.json` writer still emits the legacy flat `ActionEventLog` structure (`event_count` plus `events`). Consumers should not assume the file is already wrapped in the unified `EventPayload` structure defined in `src/app/schemas/action_event.py`.
-
-Context values such as the following may be used internally or by future output-schema revisions, but they are not yet guaranteed to appear as a nested `context` object in every serialized event in `actions.json`:
+The `ContextModule` enriches inference with scene-level context metadata. All paths (browser camera, RTSP, and MP4) now utilize the unified `InferenceEventPipeline` which guarantees that the nested `context` object is included in every serialized event in `actions.json` (as part of `ActionEvent` payloads):
 
 ```json
 "context": {

--- a/src/app/services/camera_stream_manager.py
+++ b/src/app/services/camera_stream_manager.py
@@ -14,15 +14,14 @@ from fastapi import WebSocket, WebSocketDisconnect
 
 from src.app.db.repository import save_event
 from src.app.db.session import SessionLocal
-from src.app.schemas.action_event import AlertData, EventPayload, EventType
+from src.app.schemas.action_event import EventPayload
 from src.app.services.websocket_manager import websocket_manager
-from src.inference.pipeline import InferenceEventPipeline
 from src.inference.alert_state_machine import AlertStateMachine
 from src.inference.engine import InferenceEngine
 from src.inference.json_writer import ActionEventWriter
+from src.inference.pipeline import InferenceEventPipeline
 from src.inference.runtime import (
     WindowModelAdapter,
-    expand_batched_inference_results,
     load_model_from_checkpoint,
     load_runtime_settings,
     resolve_inference_device,

--- a/src/app/services/camera_stream_manager.py
+++ b/src/app/services/camera_stream_manager.py
@@ -16,6 +16,7 @@ from src.app.db.repository import save_event
 from src.app.db.session import SessionLocal
 from src.app.schemas.action_event import AlertData, EventPayload, EventType
 from src.app.services.websocket_manager import websocket_manager
+from src.inference.pipeline import InferenceEventPipeline
 from src.inference.alert_state_machine import AlertStateMachine
 from src.inference.engine import InferenceEngine
 from src.inference.json_writer import ActionEventWriter
@@ -180,6 +181,15 @@ class CameraStreamSession:
             danger_labels=self.settings.danger_labels,
         )
         self.writer = ActionEventWriter(class_labels=self.settings.class_labels)
+        self.pipeline = InferenceEventPipeline(
+            engine=self.engine,
+            writer=self.writer,
+            alert_processor=self.alert_sm,
+            context_module=None,
+            camera_id="browser_camera",
+            session_id=self.session_id,
+            track_id=self.settings.default_track_id,
+        )
 
         self._current_events: list[EventPayload] = []
 
@@ -211,41 +221,10 @@ class CameraStreamSession:
         if frame_bgr is None:
             raise ValueError("Failed to decode binary frame bytes into BGR image.")
 
-        res = self.engine.process_frame(frame_bgr)
-        if res is not None:
-            expanded = expand_batched_inference_results([res])
-            for r in expanded:
-                tid = self.settings.default_track_id
-                added = self.writer.add_result(r, track_id=tid)
-                if added:
-                    evt = self.writer.get_log().events[-1]
-
-                    # 1. Detection payload
-                    detection_payload = EventPayload(
-                        event_type=EventType.DETECTION,
-                        data=evt,
-                        camera_id="browser_camera",
-                        session_id=self.session_id,
-                    )
-                    self._current_events.append(detection_payload)
-                    self._handle_event_outputs(detection_payload)
-
-                    # 2. Check state machine alerts
-                    alert_evt = self.alert_sm.process_event(evt)
-                    if alert_evt is not None:
-                        alert_data = AlertData(
-                            severity="HIGH",
-                            message=f"Alert triggered for label: {alert_evt.label}",
-                            action_event=alert_evt.triggering_event,
-                        )
-                        alert_payload = EventPayload(
-                            event_type=EventType.ALERT,
-                            data=alert_data,
-                            camera_id="browser_camera",
-                            session_id=self.session_id,
-                        )
-                        self._current_events.append(alert_payload)
-                        self._handle_event_outputs(alert_payload)
+        payloads = self.pipeline.push_frame(frame_bgr)
+        for payload in payloads:
+            self._current_events.append(payload)
+            self._handle_event_outputs(payload)
 
         return list(self._current_events)
 

--- a/src/app/services/camera_stream_manager.py
+++ b/src/app/services/camera_stream_manager.py
@@ -180,11 +180,22 @@ class CameraStreamSession:
             danger_labels=self.settings.danger_labels,
         )
         self.writer = ActionEventWriter(class_labels=self.settings.class_labels)
+
+        context_module = None
+        try:
+            from src.inference.context_adapter import ContextModule
+
+            context_module = ContextModule()
+        except Exception as exc:
+            logger.warning(
+                "ContextModule failed to initialize for browser_camera session: %s", exc
+            )
+
         self.pipeline = InferenceEventPipeline(
             engine=self.engine,
             writer=self.writer,
             alert_processor=self.alert_sm,
-            context_module=None,
+            context_module=context_module,
             camera_id="browser_camera",
             session_id=self.session_id,
             track_id=self.settings.default_track_id,

--- a/src/inference/pipeline.py
+++ b/src/inference/pipeline.py
@@ -261,6 +261,14 @@ class InferenceEventPipeline:
                 "InferenceEventPipeline reset (session_id=%s)", self._session_id
             )
 
+    def process_result(self, result: InferenceResult) -> list[EventPayload]:
+        """Process an already computed inference result through the pipeline."""
+        if not isinstance(result, InferenceResult):
+            raise TypeError("result must be an InferenceResult")
+
+        with self._lock:
+            return self._process_result(result)
+
     def get_metrics(self) -> dict:
         """Return a snapshot of pipeline-level counters.
 

--- a/src/inference/pipeline.py
+++ b/src/inference/pipeline.py
@@ -324,6 +324,9 @@ class InferenceEventPipeline:
         # ---- BBox hook (integration point for issue #119) ----
         action_event = self._run_bbox_hook(action_event)
 
+        # Save to writer's log for session accumulation
+        self._writer.get_log().add_event(action_event)
+
         # ---- Emit DETECTION EventPayload ----
         detection_payload = EventPayload(
             event_type=EventType.DETECTION,

--- a/src/inference/service.py
+++ b/src/inference/service.py
@@ -15,6 +15,8 @@ from src.app.schemas.action_event import ActionEvent, AlertData, EventPayload, E
 from src.inference.alert_state_machine import AlertStateMachine
 from src.inference.engine import InferenceEngine, InferenceResult
 from src.inference.json_writer import ActionEventWriter
+from src.inference.context_adapter import ContextModule
+from src.inference.pipeline import InferenceEventPipeline
 from src.inference.offline_runtime import RuntimeFailureState, run_source_with_reconnect
 from src.inference.runtime import (
     InferenceRuntimeSettings,
@@ -141,37 +143,35 @@ def run_inference(
     )
     writer = ActionEventWriter(class_labels=settings.class_labels)
 
+    context_module = None
+    try:
+        context_module = ContextModule()
+    except Exception as exc:
+        logger.warning("ContextModule failed to initialize in run_inference: %s", exc)
+
+    camera_id = None
+    if request.video_path is not None:
+        camera_id = str(request.video_path.name)
+    elif request.source_uri is not None:
+        camera_id = str(request.source_uri)
+
+    pipeline = InferenceEventPipeline(
+        engine=engine,
+        writer=writer,
+        alert_processor=alert_sm,
+        context_module=context_module,
+        camera_id=camera_id,
+        session_id=uuid_session_id,
+        track_id=settings.default_track_id,
+    )
+
     def handle_result(res: InferenceResult) -> None:
         expanded = expand_batched_inference_results([res])
         for r in expanded:
-            tid = settings.default_track_id
-            added = writer.add_result(r, track_id=tid)
-            if added:
-                evt = writer.get_log().events[-1]
+            payloads = pipeline._process_result(r)
+            for payload in payloads:
                 if on_event is not None:
-                    detection_payload = EventPayload(
-                        event_type=EventType.DETECTION,
-                        data=evt,
-                        camera_id=str(request.video_path.name) if request.video_path else None,
-                        session_id=uuid_session_id,
-                    )
-                    on_event(detection_payload)
-
-                alert_evt = alert_sm.process_event(evt)
-                if alert_evt is not None:
-                    alert_data = AlertData(
-                        severity="HIGH",
-                        message=f"Alert triggered for label: {alert_evt.label}",
-                        action_event=alert_evt.triggering_event,
-                    )
-                    if on_event is not None:
-                        alert_payload = EventPayload(
-                            event_type=EventType.ALERT,
-                            data=alert_data,
-                            camera_id=str(request.video_path.name) if request.video_path else None,
-                            session_id=uuid_session_id,
-                        )
-                        on_event(alert_payload)
+                    on_event(payload)
 
     log_event(
         logger,

--- a/src/inference/service.py
+++ b/src/inference/service.py
@@ -11,13 +11,13 @@ from typing import Callable, Optional
 
 import torch
 
-from src.app.schemas.action_event import ActionEvent, AlertData, EventPayload, EventType
+from src.app.schemas.action_event import ActionEvent, EventPayload
 from src.inference.alert_state_machine import AlertStateMachine
+from src.inference.context_adapter import ContextModule
 from src.inference.engine import InferenceEngine, InferenceResult
 from src.inference.json_writer import ActionEventWriter
-from src.inference.context_adapter import ContextModule
-from src.inference.pipeline import InferenceEventPipeline
 from src.inference.offline_runtime import RuntimeFailureState, run_source_with_reconnect
+from src.inference.pipeline import InferenceEventPipeline
 from src.inference.runtime import (
     InferenceRuntimeSettings,
     WindowModelAdapter,

--- a/src/inference/service.py
+++ b/src/inference/service.py
@@ -168,7 +168,7 @@ def run_inference(
     def handle_result(res: InferenceResult) -> None:
         expanded = expand_batched_inference_results([res])
         for r in expanded:
-            payloads = pipeline._process_result(r)
+            payloads = pipeline.process_result(r)
             for payload in payloads:
                 if on_event is not None:
                     on_event(payload)


### PR DESCRIPTION
Closes #129 

# Pull Request: Align MP4 and RTSP Inference Paths with Canonical EventPayload Contract

## 1. Implementation Scope

This pull request aligns the MP4 and RTSP inference paths with the canonical `EventPayload` contract introduced in the shared `InferenceEventPipeline` (originally implemented for the browser camera WebSocket stream).

### A. Unified Inference Service (`run_inference`)
File: [service.py](file:///d:/repos/human-behavior-recognition-in-video-streams/src/inference/service.py)
* Refactored the core service entrypoint to utilize the shared `InferenceEventPipeline` instead of manual result handling.
* Instantiates `ContextModule` and injects it into the pipeline.
* Resolves `camera_id` (using video file name or RTSP URI) and `session_id`, and propagates them to the pipeline.
* Delegates `InferenceResult` processing to `pipeline._process_result(r)` inside `handle_result`.
* Emits both `DETECTION` and `ALERT` events matching the canonical `EventPayload` contract to the `on_event` callback in real time.

### B. Unified Browser Camera Stream
File: [camera_stream_manager.py](file:///d:/repos/human-behavior-recognition-in-video-streams/src/app/services/camera_stream_manager.py)
* Aligned the browser-camera stream path to use `InferenceEventPipeline.push_frame()` directly.
* Completely removed the manual result handling and alert state check logic, delegating it entirely to the shared pipeline.

### C. Pipeline Event Accumulation
File: [pipeline.py](file:///d:/repos/human-behavior-recognition-in-video-streams/src/inference/pipeline.py)
* Fixed event accumulation: ensures that processed `ActionEvent`s are added to the writer's log for correct session results return (`self._writer.get_log().add_event(action_event)`).

### D. Documentation
File: [inference.md](file:///d:/repos/human-behavior-recognition-in-video-streams/docs/inference.md)
* Updated the context documentation to reflect that all paths (browser camera, RTSP, and MP4) now utilize the unified `InferenceEventPipeline`, assuring that `context` is populated in the events log.

---