### PR TITLE
Add MP4 inference performance benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,15 @@ For final demo setup, infrastructure smoke verification, and MP4 fallback infere
 
 The smoke helper uses the existing dummy checkpoint path to verify the stack. Repeat MP4 inference with the final checkpoint after issue #130 publishes it.
 
+## Performance Measurement
+
+For repeatable MP4 inference latency/FPS measurements, run the benchmark documented in [Performance Benchmark](docs/performance-benchmark.md). Re-run it with the final checkpoint after issue #130 publishes that checkpoint.
+
+```powershell
+.\scripts\benchmark_mp4_inference.ps1 -Input data\raw\<video>.mp4 -Checkpoint data\logs\checkpoints\<checkpoint>.pth -Device auto
+.\scripts\benchmark_mp4_inference.ps1 -Input data\raw\<video>.mp4 -Checkpoint data\logs\checkpoints\<checkpoint>.pth -Device cuda -Gpu
+```
+
 ### Configuration
 
 Backend configuration is managed through environment variables in `src/app/core/settings.py`:
@@ -190,6 +199,7 @@ Inference mode requires `--input` and `--checkpoint` together. Without these arg
 - [Frontend](docs/frontend.md)
 - [Integration and DevOps](docs/integration-devops.md)
 - [Final Demo Runbook](docs/final-demo-runbook.md)
+- [Performance Benchmark](docs/performance-benchmark.md)
 - [Contributing](docs/contributing.md)
 - [CI Workflows](docs/ci-workflows.md)
 

--- a/docs/performance-benchmark.md
+++ b/docs/performance-benchmark.md
@@ -1,0 +1,98 @@
+# Performance Benchmark
+
+## Purpose
+
+This benchmark provides a repeatable MP4 inference measurement path for the current system. It reports measured wall-clock throughput and latency-style values from an actual run instead of estimated performance claims.
+
+The benchmark is intended for smoke-level performance reporting. It does not train a model, optimize runtime, or prove that the project meets a particular FPS or latency target by itself.
+
+## Run The Benchmark
+
+From Windows PowerShell:
+
+```powershell
+.\scripts\benchmark_mp4_inference.ps1 `
+  -Input .\data\raw\car_makes_u_turn\0A2BF1E8-55E5-4D3D-9B7D-59929025D9CC_0.mp4 `
+  -Checkpoint .\data\logs\checkpoints\baseline_epoch_50.pth `
+  -Output .\data\logs\benchmark_summary.json `
+  -Device auto
+```
+
+For the NVIDIA GPU Compose override, pass `-Gpu` and request CUDA:
+
+```powershell
+.\scripts\benchmark_mp4_inference.ps1 `
+  -Input .\data\raw\car_makes_u_turn\0A2BF1E8-55E5-4D3D-9B7D-59929025D9CC_0.mp4 `
+  -Checkpoint .\data\logs\checkpoints\baseline_epoch_50.pth `
+  -Output .\data\logs\benchmark_summary_gpu.json `
+  -Device cuda `
+  -Gpu
+```
+
+Optional arguments:
+
+- `-Config` defaults to `configs/data_pipeline.yml`.
+- `-Output` defaults to `data/logs/benchmark_summary.json`.
+- `-Device` accepts `auto`, `cpu`, `cuda`, or `mps`.
+- `-Gpu` uses `docker compose -f compose.yaml -f compose.gpu.yaml run --rm inference ...`.
+
+Without `-Gpu`, the wrapper uses the default CPU-safe Compose path: `docker compose run --rm inference ...`.
+
+The wrapper validates the input MP4, checkpoint, and config paths, creates the output directory, runs the benchmark through the Docker Compose `inference` service, and prints the JSON output path.
+
+You can also run the Python script directly inside an environment with the project dependencies installed:
+
+```powershell
+python .\scripts\benchmark_mp4_inference.py `
+  --input .\data\raw\car_makes_u_turn\0A2BF1E8-55E5-4D3D-9B7D-59929025D9CC_0.mp4 `
+  --checkpoint .\data\logs\checkpoints\baseline_epoch_50.pth `
+  --config .\configs\data_pipeline.yml `
+  --output .\data\logs\benchmark_summary.json `
+  --device auto
+```
+
+## Output Values
+
+The JSON summary is machine-readable and includes:
+
+- `timestamp`: UTC time when the benchmark summary was produced.
+- `host`: operating system and platform metadata.
+- `python_version`: Python runtime version used by the benchmark process.
+- `cpu`: CPU metadata available from Python and the host environment.
+- `cuda`: PyTorch/CUDA availability and CUDA device names when available.
+- `requested_device`: value passed with `--device` or `-Device`.
+- `resolved_runtime_device`: device selected by the inference runtime.
+- `input_video_path`, `checkpoint_path`, `config_path`: files used for the run.
+- `window_size`: temporal window size loaded from the config.
+- `stride`: inference stride loaded from the config.
+- `target_resolution`: frame resolution used by the runtime tensorizer.
+- `frame_count`: frames read and processed from the MP4.
+- `inference_count`: number of inference windows produced.
+- `event_count`: number of action events emitted by the pipeline.
+- `total_wall_clock_duration_s`: measured duration for one complete offline MP4 inference run.
+- `approx_processed_fps`: `frame_count / total_wall_clock_duration_s`.
+- `approx_inference_windows_per_second`: `inference_count / total_wall_clock_duration_s`.
+- `average_time_per_inference_window_s`: `total_wall_clock_duration_s / inference_count`.
+- `limitations`: notes copied into the result to keep interpretation attached to the numbers.
+
+## Limitations
+
+This benchmark is a single-run offline MP4 wall-clock measurement. The duration includes model loading, video decode, preprocessing, inference, event pipeline work, and any enabled context or bounding-box enrichment in the current config.
+
+It does not measure live camera capture-to-display latency, frontend rendering latency, network latency, or database persistence latency. For final reporting, run the benchmark more than once on the target machine and report the hardware, checkpoint, config, and device alongside the numbers.
+
+The final benchmark must be re-run after issue #130 publishes the final checkpoint. Until then, measurements from `baseline_epoch_50.pth` are smoke measurements only and must not be treated as final project performance.
+
+## Current Non-Final Smoke Measurements
+
+These measurements were captured locally on 2026-06-24 using `data/logs/checkpoints/baseline_epoch_50.pth`. That checkpoint is not the final checkpoint from issue #130, so every result in this table is a non-final smoke measurement only.
+
+All three runs used the same MP4 input: `data/raw/car_makes_u_turn/0A2BF1E8-55E5-4D3D-9B7D-59929025D9CC_0.mp4`.
+
+| Run | Device/path | Frames | Inference windows | Events | Wall-clock duration | Approx processed FPS | Approx inference windows/s | Avg time/window | Notes |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| Docker CPU smoke | CPU in Docker, default Compose | `369` | `23` | `23` | `35.728842 s` | `10.327791` | `0.643738` | `1.553428 s` | Includes current Docker/container initialization behavior, including MobileNet weight download during startup. This is not a final steady-state claim. |
+| Local Python CPU smoke | CPU in local `.venv` | `369` | `23` | `23` | `27.426661 s` | `13.454062` | `0.8386` | Not recorded | Not directly comparable with Docker because local Python used BBoxEnricher fallback behavior without `ultralytics` installed. |
+| Docker GPU smoke | CUDA in Docker with `compose.gpu.yaml` | `369` | `23` | `23` | `8.536578 s` | `43.225751` | `2.694288` | Not recorded | Use `43.225751` FPS as the main benchmark-script value. The internal runtime log showed about `3.612 s`, but runtime-only FPS is not the main result. |
+
+Final performance must be re-measured after issue #130 publishes the final checkpoint. Do not use these smoke measurements to claim that the project meets 15 FPS or <= 2 s end-to-end latency.

--- a/docs/performance-benchmark.md
+++ b/docs/performance-benchmark.md
@@ -91,8 +91,8 @@ All three runs used the same MP4 input: `data/raw/car_makes_u_turn/0A2BF1E8-55E5
 
 | Run | Device/path | Frames | Inference windows | Events | Wall-clock duration | Approx processed FPS | Approx inference windows/s | Avg time/window | Notes |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
-| Docker CPU smoke | CPU in Docker, default Compose | `369` | `23` | `23` | `35.728842 s` | `10.327791` | `0.643738` | `1.553428 s` | Includes current Docker/container initialization behavior, including MobileNet weight download during startup. This is not a final steady-state claim. |
-| Local Python CPU smoke | CPU in local `.venv` | `369` | `23` | `23` | `27.426661 s` | `13.454062` | `0.8386` | Not recorded | Not directly comparable with Docker because local Python used BBoxEnricher fallback behavior without `ultralytics` installed. |
-| Docker GPU smoke | CUDA in Docker with `compose.gpu.yaml` | `369` | `23` | `23` | `8.536578 s` | `43.225751` | `2.694288` | Not recorded | Use `43.225751` FPS as the main benchmark-script value. The internal runtime log showed about `3.612 s`, but runtime-only FPS is not the main result. |
+| Docker CPU smoke | CPU in Docker, default Compose | `369` | `23` | `23` | `35.162069 s` | `10.494263` | `0.654114` | `1.528786 s` | Non-final smoke measurement using `baseline_epoch_50.pth`. Includes Docker/container initialization and model startup behavior. |
+| Local Python CPU smoke | CPU in local `.venv` | `369` | `23` | `23` | `26.020006 s` | `14.181396` | `0.883935` | `1.131305 s` | Not directly comparable with Docker because local Python used BBoxEnricher fallback behavior without `ultralytics` installed. |
+| Docker GPU smoke | CUDA in Docker with `compose.gpu.yaml` | `369` | `23` | `23` | `11.127545 s` | `33.160954` | `2.066943` | `0.483806 s` | Non-final smoke measurement using `baseline_epoch_50.pth`. Confirms the Docker CUDA path works, but final performance must be re-measured after #130. |
 
 Final performance must be re-measured after issue #130 publishes the final checkpoint. Do not use these smoke measurements to claim that the project meets 15 FPS or <= 2 s end-to-end latency.

--- a/scripts/benchmark_mp4_inference.ps1
+++ b/scripts/benchmark_mp4_inference.ps1
@@ -1,0 +1,175 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [Alias("Input")]
+    [string]$InputPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Checkpoint,
+
+    [string]$Config = "configs/data_pipeline.yml",
+    [string]$Output = "data/logs/benchmark_summary.json",
+    [ValidateSet("auto", "cpu", "cuda", "mps")]
+    [string]$Device = "auto",
+    [switch]$Gpu
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-DockerComposeCommand {
+    if (Get-Command docker -ErrorAction SilentlyContinue) {
+        & docker compose version *> $null
+        if ($LASTEXITCODE -eq 0) {
+            return @("docker", "compose")
+        }
+    }
+
+    if (Get-Command docker-compose -ErrorAction SilentlyContinue) {
+        & docker-compose version *> $null
+        if ($LASTEXITCODE -eq 0) {
+            return @("docker-compose")
+        }
+    }
+
+    throw "Docker Compose is unavailable. Install Docker Desktop or ensure 'docker compose' is on PATH."
+}
+
+function Invoke-Compose {
+    param(
+        [string[]]$Arguments
+    )
+
+    $exe = $script:ComposeCommand[0]
+    $baseArgs = @()
+    if ($script:ComposeCommand.Count -gt 1) {
+        $baseArgs = $script:ComposeCommand[1..($script:ComposeCommand.Count - 1)]
+    }
+
+    & $exe @baseArgs @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Docker Compose command failed with exit code $LASTEXITCODE`: $($Arguments -join ' ')"
+    }
+}
+
+function Test-IsAppPath {
+    param([string]$Path)
+
+    $normalized = $Path.Replace("\", "/")
+    return $normalized.StartsWith("/app/")
+}
+
+function Convert-AppPathToHostPath {
+    param([string]$Path)
+
+    $relative = $Path.Replace("\", "/").Substring(5)
+    return [System.IO.Path]::GetFullPath((Join-Path $script:RepoRoot ($relative.Replace("/", [System.IO.Path]::DirectorySeparatorChar))))
+}
+
+function Get-HostPath {
+    param(
+        [string]$Path,
+        [switch]$MustExist
+    )
+
+    if (Test-IsAppPath -Path $Path) {
+        $hostPath = Convert-AppPathToHostPath -Path $Path
+    }
+    elseif ([System.IO.Path]::IsPathRooted($Path)) {
+        $hostPath = [System.IO.Path]::GetFullPath($Path)
+    }
+    else {
+        $hostPath = [System.IO.Path]::GetFullPath((Join-Path $script:RepoRoot $Path))
+    }
+
+    if ($MustExist -and -not (Test-Path -LiteralPath $hostPath -PathType Leaf)) {
+        throw "Required file does not exist: $hostPath"
+    }
+
+    return $hostPath
+}
+
+function Convert-HostPathToContainerPath {
+    param([string]$HostPath)
+
+    $repoRootWithSeparator = $script:RepoRoot.TrimEnd([System.IO.Path]::DirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
+    $fullPath = [System.IO.Path]::GetFullPath($HostPath)
+
+    if (-not $fullPath.StartsWith($repoRootWithSeparator, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Path must be inside the repository so Docker Compose can mount it: $fullPath"
+    }
+
+    $relative = $fullPath.Substring($repoRootWithSeparator.Length).Replace("\", "/")
+    return "/app/$relative"
+}
+
+$script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+Set-Location $script:RepoRoot
+
+$inputHostPath = Get-HostPath -Path $InputPath -MustExist
+$checkpointHostPath = Get-HostPath -Path $Checkpoint -MustExist
+$configHostPath = Get-HostPath -Path $Config -MustExist
+$outputHostPath = Get-HostPath -Path $Output
+
+if ([System.IO.Path]::GetExtension($inputHostPath).ToLowerInvariant() -ne ".mp4") {
+    throw "Input must be an MP4 file: $inputHostPath"
+}
+
+$outputDirectory = Split-Path -Parent $outputHostPath
+if ($outputDirectory) {
+    New-Item -ItemType Directory -Force -Path $outputDirectory | Out-Null
+}
+
+$containerInput = if (Test-IsAppPath -Path $InputPath) { $InputPath.Replace("\", "/") } else { Convert-HostPathToContainerPath -HostPath $inputHostPath }
+$containerCheckpoint = if (Test-IsAppPath -Path $Checkpoint) { $Checkpoint.Replace("\", "/") } else { Convert-HostPathToContainerPath -HostPath $checkpointHostPath }
+$containerConfig = if (Test-IsAppPath -Path $Config) { $Config.Replace("\", "/") } else { Convert-HostPathToContainerPath -HostPath $configHostPath }
+$containerOutput = if (Test-IsAppPath -Path $Output) { $Output.Replace("\", "/") } else { Convert-HostPathToContainerPath -HostPath $outputHostPath }
+
+$script:ComposeCommand = @(Get-DockerComposeCommand)
+Write-Host "Using Docker Compose command: $($script:ComposeCommand -join ' ')"
+if ($Gpu) {
+    Write-Host "Compose mode: GPU override (compose.yaml + compose.gpu.yaml)"
+}
+else {
+    Write-Host "Compose mode: default CPU-safe compose.yaml"
+}
+Write-Host "Running MP4 inference benchmark..."
+Write-Host "  Input:      $inputHostPath"
+Write-Host "  Checkpoint: $checkpointHostPath"
+Write-Host "  Config:     $configHostPath"
+Write-Host "  Output:     $outputHostPath"
+Write-Host "  Device:     $Device"
+
+$composeArgs = @()
+if ($Gpu) {
+    $composeArgs += @(
+        "-f",
+        "compose.yaml",
+        "-f",
+        "compose.gpu.yaml"
+    )
+}
+
+$composeArgs += @(
+    "run",
+    "--rm",
+    "inference",
+    "python",
+    "scripts/benchmark_mp4_inference.py",
+    "--input",
+    $containerInput,
+    "--checkpoint",
+    $containerCheckpoint,
+    "--config",
+    $containerConfig,
+    "--output",
+    $containerOutput,
+    "--device",
+    $Device
+)
+
+Invoke-Compose -Arguments $composeArgs
+
+Write-Host ""
+Write-Host "MP4 inference benchmark completed."
+Write-Host "Benchmark JSON: $outputHostPath"

--- a/scripts/benchmark_mp4_inference.py
+++ b/scripts/benchmark_mp4_inference.py
@@ -1,0 +1,251 @@
+"""Measure MP4 inference wall-clock performance and write a JSON summary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from src.inference.service import InferenceServiceRequest, run_offline_mp4_inference  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the MP4 benchmark CLI parser."""
+    parser = argparse.ArgumentParser(
+        description="Run MP4 inference once and write measured performance metrics as JSON.",
+    )
+    parser.add_argument(
+        "--input",
+        required=True,
+        dest="input_path",
+        help="Path to the input MP4 video.",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        required=True,
+        dest="checkpoint_path",
+        help="Path to the model checkpoint.",
+    )
+    parser.add_argument(
+        "--config",
+        default="configs/data_pipeline.yml",
+        dest="config_path",
+        help="Path to the inference/data pipeline YAML config.",
+    )
+    parser.add_argument(
+        "--output",
+        default="data/logs/benchmark_summary.json",
+        dest="output_path",
+        help="Path where the benchmark summary JSON should be written.",
+    )
+    parser.add_argument(
+        "--device",
+        default="auto",
+        choices=["auto", "cpu", "cuda", "mps"],
+        help="Requested inference device.",
+    )
+    return parser
+
+
+def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
+    """Run offline MP4 inference and return measured benchmark data."""
+    input_path = Path(args.input_path)
+    checkpoint_path = Path(args.checkpoint_path)
+    config_path = Path(args.config_path)
+
+    _validate_existing_file(input_path, "--input")
+    _validate_existing_file(checkpoint_path, "--checkpoint")
+    _validate_existing_file(config_path, "--config")
+    if input_path.suffix.lower() != ".mp4":
+        raise ValueError(f"--input must point to an MP4 file: {input_path}")
+
+    request = InferenceServiceRequest(
+        video_path=input_path,
+        checkpoint_path=checkpoint_path,
+        config_path=config_path,
+        device=args.device,
+    )
+
+    start_time = time.perf_counter()
+    result = run_offline_mp4_inference(request)
+    total_duration_s = time.perf_counter() - start_time
+
+    frame_count = result.frame_count
+    inference_count = result.inference_count
+    event_count = result.event_count
+
+    processed_fps = _safe_rate(frame_count, total_duration_s)
+    inference_windows_per_second = _safe_rate(inference_count, total_duration_s)
+    average_time_per_inference_window_s = (
+        total_duration_s / inference_count if inference_count else None
+    )
+
+    settings = result.runtime_settings
+    return {
+        "timestamp": _utc_timestamp(),
+        "host": _host_info(),
+        "python_version": platform.python_version(),
+        "cpu": _cpu_info(),
+        "cuda": _cuda_info(),
+        "requested_device": args.device,
+        "resolved_runtime_device": str(result.resolved_device),
+        "input_video_path": str(input_path),
+        "checkpoint_path": str(checkpoint_path),
+        "config_path": str(config_path),
+        "window_size": settings.window_size,
+        "stride": settings.stride,
+        "target_resolution": list(settings.target_resolution),
+        "frame_count": frame_count,
+        "inference_count": inference_count,
+        "event_count": event_count,
+        "total_wall_clock_duration_s": _round_float(total_duration_s),
+        "approx_processed_fps": _round_float(processed_fps),
+        "approx_inference_windows_per_second": _round_float(
+            inference_windows_per_second,
+        ),
+        "average_time_per_inference_window_s": _round_float(
+            average_time_per_inference_window_s,
+        ),
+        "limitations": [
+            "Single-run offline MP4 wall-clock measurement; "
+            "repeat runs before using as final data.",
+            "Includes model loading, video decode, preprocessing, inference, "
+            "and event pipeline work.",
+            "Does not measure live camera capture-to-display latency.",
+            "Current checkpoint should not be treated as final until issue #130 publishes it.",
+        ],
+    }
+
+
+def write_summary(summary: dict[str, Any], output_path: Path) -> None:
+    """Write benchmark summary JSON to disk."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(summary, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _validate_existing_file(path: Path, argument_name: str) -> None:
+    if not path.exists():
+        raise FileNotFoundError(f"{argument_name} file does not exist: {path}")
+    if not path.is_file():
+        raise ValueError(f"{argument_name} must point to a file: {path}")
+
+
+def _safe_rate(count: int, duration_s: float) -> float | None:
+    if duration_s <= 0:
+        return None
+    return count / duration_s
+
+
+def _round_float(value: float | None) -> float | None:
+    if value is None:
+        return None
+    return round(value, 6)
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _host_info() -> dict[str, str]:
+    uname = platform.uname()
+    return {
+        "system": uname.system,
+        "release": uname.release,
+        "version": uname.version,
+        "machine": uname.machine,
+        "processor": uname.processor,
+        "platform": platform.platform(),
+    }
+
+
+def _cpu_info() -> dict[str, Any]:
+    return {
+        "processor": platform.processor(),
+        "model_name": _linux_cpu_model_name(),
+        "machine": platform.machine(),
+        "logical_cpu_count": os.cpu_count(),
+        "processor_identifier": os.environ.get("PROCESSOR_IDENTIFIER"),
+    }
+
+
+def _linux_cpu_model_name() -> str | None:
+    cpuinfo_path = Path("/proc/cpuinfo")
+    if not cpuinfo_path.exists():
+        return None
+
+    try:
+        for line in cpuinfo_path.read_text(encoding="utf-8").splitlines():
+            if line.lower().startswith("model name"):
+                return line.split(":", maxsplit=1)[1].strip()
+    except OSError:
+        return None
+    return None
+
+
+def _cuda_info() -> dict[str, Any]:
+    try:
+        import torch
+    except ImportError:
+        return {
+            "torch_available": False,
+            "cuda_available": False,
+            "notes": "torch import failed; CUDA availability was not checked.",
+        }
+
+    cuda_available = bool(torch.cuda.is_available())
+    cuda_device_count = int(torch.cuda.device_count()) if cuda_available else 0
+    device_names = [
+        torch.cuda.get_device_name(index)
+        for index in range(cuda_device_count)
+    ]
+    return {
+        "torch_available": True,
+        "torch_version": torch.__version__,
+        "torch_cuda_version": torch.version.cuda,
+        "cuda_available": cuda_available,
+        "cuda_device_count": cuda_device_count,
+        "cuda_device_names": device_names,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the benchmark CLI."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    output_path = Path(args.output_path)
+
+    try:
+        summary = run_benchmark(args)
+        write_summary(summary, output_path)
+    except Exception as error:
+        print(f"[ERROR] {error}", file=sys.stderr)
+        return 1
+
+    print("MP4 inference benchmark completed.")
+    print(f"Output JSON: {output_path}")
+    print(f"Frames: {summary['frame_count']}")
+    print(f"Inference windows: {summary['inference_count']}")
+    print(f"Action events: {summary['event_count']}")
+    print(f"Wall-clock duration: {summary['total_wall_clock_duration_s']} s")
+    print(f"Approx processed FPS: {summary['approx_processed_fps']}")
+    print(
+        "Approx inference windows/s: "
+        f"{summary['approx_inference_windows_per_second']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a repeatable MP4 inference benchmark for issue #137.

The PR adds a Python benchmark runner, a PowerShell wrapper with CPU/GPU Compose support, benchmark documentation, and a short README link. The benchmark measures wall-clock duration, approximate FPS, inference windows/s, time per window, and records checkpoint/config/device metadata.

## Linked Issue

Closes #137

## Testing

- [x] CPU Docker benchmark verified
- [x] GPU Docker benchmark verified
- [x] Local Python CPU benchmark verified
- [x] README/docs updated
- [x] CI passes

Latest non-final smoke results using `baseline_epoch_50.pth`:

| Run | FPS | Duration | Device |
|---|---:|---:|---|
| Docker CPU | `10.494263` | `35.162069 s` | CPU |
| Docker GPU | `33.160954` | `11.127545 s` | CUDA |
| Local Python CPU | `14.181396` | `26.020006 s` | CPU |

## Notes

All measurements are non-final smoke measurements. Final performance must be re-run after issue #130 publishes the final checkpoint.

No model, training, API, UI, or runtime optimization changes are included.