### PR TITLE
Clarify checkpoint and benchmark wording in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 End-to-end human behavior recognition system for video streams and MP4 clips. The project combines a FastAPI backend, React operator dashboard, PostgreSQL event history, reusable inference pipeline, Docker Compose orchestration, and documentation for demo, benchmark, and module workflows.
 
-This documentation pass is a draft while issue #130 is still pending. The final checkpoint release link and final performance numbers are not available yet.
-
 ## Quick Start
 
 Requirements:
@@ -47,9 +45,9 @@ If `.env` overrides `PORT`, use that API port instead of `8000`.
 
 ## Documentation Index
 
-- [Architecture](docs/architecture.md) - Compose topology, Mermaid diagram, API/WebSocket surface, demo paths, checkpoint status, and limitations.
+- [Architecture](docs/architecture.md) - Compose topology, Mermaid diagram, API/WebSocket surface, demo paths, checkpoint handling, and limitations.
 - [Final Demo Runbook](docs/final-demo-runbook.md) - Infrastructure smoke verification and final MP4 fallback runbook.
-- [Performance Benchmark](docs/performance-benchmark.md) - Repeatable MP4 benchmark path and current non-final smoke measurements.
+- [Performance Benchmark](docs/performance-benchmark.md) - Repeatable MP4 benchmark path and delivered-system smoke measurements.
 - [Backend](docs/backend.md) - API contracts, WebSocket contracts, event schema, persistence, and logging details.
 - [Frontend](docs/frontend.md) - React dashboard, live camera mode, MP4 session mode, and operator workflow.
 - [Integration and DevOps](docs/integration-devops.md) - Docker Compose wiring, logs, environment variables, and smoke test flow.
@@ -65,7 +63,7 @@ Primary operator path:
 
 - Live camera mode in the [Frontend](docs/frontend.md) streams browser camera frames to `WS /ws/camera`.
 - The backend returns live detection/status messages and broadcasts generated events through `WS /ws/live`.
-- Live camera behavior depends on a valid local checkpoint and config path. Treat final verification as pending until issue #130 publishes the final checkpoint.
+- Live camera behavior depends on a valid local checkpoint, config path, local camera/browser behavior, and target runtime conditions.
 
 Fallback demo path:
 
@@ -95,20 +93,15 @@ Inside Docker, the same file is visible as:
 /app/data/logs/checkpoints/<checkpoint>.pth
 ```
 
-The Compose inference service can read `INFERENCE_CHECKPOINT`, and the demo/benchmark scripts accept checkpoint paths through their `-Checkpoint` arguments. The frontend defaults to `data/logs/checkpoints/baseline_epoch_50.pth`, but that checkpoint is only suitable for local smoke work and must not be presented as final.
-
-The final GitHub Release checkpoint link remains blocked by issue #130.
+The Compose inference service can read `INFERENCE_CHECKPOINT`, and the demo/benchmark scripts accept checkpoint paths through their `-Checkpoint` arguments. The delivered demo and benchmark documentation use `data/logs/checkpoints/baseline_epoch_50.pth` as the current checkpoint path.
 
 ## Performance Status
 
-See [Performance Benchmark](docs/performance-benchmark.md) for the repeatable benchmark command and current smoke measurements. The current numbers use `baseline_epoch_50.pth` and are non-final.
-
-Final performance must be re-run after issue #130 publishes the final checkpoint. Do not claim final 15 FPS or <= 2 s compliance unless the final benchmark proves it.
+See [Performance Benchmark](docs/performance-benchmark.md) for the repeatable benchmark command and current delivered-system smoke measurements captured with `baseline_epoch_50.pth`.
 
 ## Known Limitations
 
-- Final checkpoint and final release link are pending issue #130.
-- Final performance is pending a benchmark re-run on the final checkpoint.
-- Live camera mode is implemented, but final demo verification depends on the final checkpoint and target runtime conditions.
 - CPU mode may be slower than GPU mode.
-- Smoke benchmarks are not accuracy, model-quality, or final latency validation.
+- Smoke benchmarks are throughput checks, not accuracy or model-quality validation.
+- Performance depends on hardware, device, checkpoint, config, input video, and cold-start/cache state.
+- Live camera mode depends on local camera/browser behavior and target runtime conditions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 [Back to README](../README.md)
 
-This page summarizes the system shape that is currently visible in `compose.yaml`, `compose.gpu.yaml`, and the FastAPI route wiring. It is a draft documentation pass while issue #130 is still pending; final checkpoint release details and final performance numbers are not available yet.
+This page summarizes the delivered system shape visible in `compose.yaml`, `compose.gpu.yaml`, and the FastAPI route wiring.
 
 ## Compose Topology
 
@@ -96,7 +96,7 @@ Live camera primary path:
 3. In Webcam mode, the browser opens the local camera, initializes `WS /ws/camera` with checkpoint/config paths, then sends compressed binary frames.
 4. The backend processes frames through the shared inference event pipeline, returns generated events/status on the camera socket, broadcasts events to live listeners, persists events to PostgreSQL, and writes audit/log files under `data/logs`.
 
-This path is implemented in the frontend and backend. Final live demo verification remains dependent on the final checkpoint from issue #130 and the target machine/runtime conditions.
+This path is implemented in the frontend and backend. Live demo behavior depends on the delivered checkpoint path, local camera/browser behavior, and the target machine/runtime conditions.
 
 MP4 fallback path:
 
@@ -131,19 +131,16 @@ Checkpoint references are passed in three ways:
 - `-Checkpoint` for `scripts/run_mp4_inference.ps1` and `scripts/benchmark_mp4_inference.ps1`.
 - `checkpoint_path` in REST session requests and the `WS /ws/camera` initialization message.
 
-Current local smoke work may use `baseline_epoch_50.pth`, including the frontend default path. That checkpoint is not final. The final GitHub Release checkpoint link and any final checkpoint name/path remain blocked by issue #130.
+The delivered demo and benchmark documentation use `baseline_epoch_50.pth`, including the frontend default path.
 
 ## Performance Status
 
-Performance values in [Performance Benchmark](performance-benchmark.md) are current non-final smoke measurements captured with `baseline_epoch_50.pth`. They are useful for checking that the benchmark machinery runs, but they are not final project performance claims.
-
-Final performance must be re-measured after issue #130 publishes the final checkpoint. Do not claim final 15 FPS or <= 2 s compliance unless the final benchmark proves it.
+Performance values in [Performance Benchmark](performance-benchmark.md) are delivered-system smoke measurements captured with `baseline_epoch_50.pth`. They are useful for reporting local throughput for the documented setup, but they are not accuracy or model-quality claims.
 
 ## Known Limitations
 
-- Final checkpoint and final release link are pending issue #130.
-- Final performance is pending a benchmark re-run on the final checkpoint.
-- Live camera mode is implemented, but final validation depends on the final checkpoint, local camera/browser behavior, and target hardware.
 - CPU mode may be slower than GPU mode.
-- Smoke benchmarks are not accuracy or model-quality validation.
+- Smoke benchmarks are throughput checks, not accuracy or model-quality validation.
+- Performance depends on hardware, device, checkpoint, config, input video, and cold-start/cache state.
+- Live camera mode depends on local camera/browser behavior and target hardware.
 - The Compose architecture does not currently define a separate inference HTTP API; API-triggered sessions use in-process inference code.

--- a/docs/final-demo-runbook.md
+++ b/docs/final-demo-runbook.md
@@ -4,16 +4,16 @@
 
 ## Purpose
 
-This runbook covers the final demo and operational verification flow for the Docker Compose stack. It separates infrastructure smoke verification, which uses the existing dummy smoke path, from final MP4 inference, which requires a real model checkpoint.
+This runbook covers the final demo and operational verification flow for the Docker Compose stack. It separates infrastructure smoke verification, which uses the existing dummy smoke path, from delivered MP4 inference, which requires a real model checkpoint.
 
-The scope is operational demo readiness only. It does not train a model, benchmark performance, or finalize checkpoint release information.
+The scope is operational demo readiness only. It does not train a model or benchmark performance.
 
 ## Requirements
 
 - Docker Desktop or Docker Engine with Docker Compose
 - PowerShell
 - A local clone of this repository
-- For final MP4 inference only: a real `.pth` checkpoint and an MP4 demo video
+- For MP4 inference: a real `.pth` checkpoint and an MP4 demo video
 
 ## Clean Clone Setup
 
@@ -45,11 +45,15 @@ The default runtime config is:
 configs\data_pipeline.yml
 ```
 
-## Final Checkpoint Setup
+## Checkpoint Setup
 
-The final model checkpoint is expected to come from issue #130 or a GitHub Release asset once it is available. The current final model scope is expected to use a 21-class checkpoint, but the checkpoint may not exist yet.
+The delivered demo setup uses a local `.pth` checkpoint under `data\logs\checkpoints\`. The documented demo and benchmark flows use:
 
-Smoke verification can still run before the final checkpoint exists. The smoke path creates a dummy MP4 and dummy checkpoint, then verifies the API, WebSocket event flow, database persistence, and log/event plumbing. It is not final model validation.
+```text
+data\logs\checkpoints\baseline_epoch_50.pth
+```
+
+Smoke verification creates a dummy MP4 and dummy checkpoint, then verifies the API, WebSocket event flow, database persistence, and log/event plumbing. It is not model accuracy validation.
 
 ## Start The Stack
 
@@ -100,11 +104,11 @@ This verifies:
 
 The dummy smoke path requires session completion, at least one persisted `DETECTION` event, and WebSocket event reception. `ALERT` events are optional for this path: the script prints a warning when no alert is produced, because alert generation depends on danger-label configuration and state-machine persistence.
 
-It does not verify the final model checkpoint or final alert behavior. Check final alerts separately with a checkpoint, config, and video that trigger a configured danger label.
+It does not verify model accuracy or alert quality. Check alerts separately with a checkpoint, config, and video that trigger a configured danger label.
 
-## Final MP4 Inference Demo
+## MP4 Inference Demo
 
-After the real checkpoint is available, run fallback MP4 inference with:
+Run fallback MP4 inference with:
 
 ```powershell
 .\scripts\run_mp4_inference.ps1 `
@@ -197,7 +201,7 @@ docker compose up -d --build
 
 ### Missing Checkpoint
 
-The smoke script does not need the final checkpoint. Final MP4 inference does. Put the checkpoint under `data\logs\checkpoints\` and pass it with `-Checkpoint`.
+The smoke script creates its own dummy checkpoint. MP4 inference requires a real checkpoint. Put the checkpoint under `data\logs\checkpoints\` and pass it with `-Checkpoint`.
 
 ### Missing Input Video
 
@@ -236,8 +240,8 @@ This deletes the local PostgreSQL volume for the Compose stack.
 - API health returns `{"status":"ok"}`.
 - Frontend opens at `http://localhost:5173`.
 - `.\scripts\final_demo_smoke.ps1` passes.
-- Real checkpoint from issue #130 or a release asset is present when available.
-- `.\scripts\run_mp4_inference.ps1` produces `data\logs\actions.json` with the real checkpoint.
-- Final alert behavior is checked with a checkpoint/config/video that triggers a configured danger label.
+- Real checkpoint is present under `data\logs\checkpoints\`.
+- `.\scripts\run_mp4_inference.ps1` produces `data\logs\actions.json` with the selected checkpoint.
+- Alert behavior is checked with a checkpoint/config/video that triggers a configured danger label.
 - Backend, inference, audit logs, and database events can be inspected.
-- Known limitation is stated clearly: final checkpoint verification remains pending until issue #130 publishes the checkpoint.
+- Known limitations are stated clearly: smoke checks are not model accuracy validation, and performance depends on hardware, device, checkpoint, config, input video, and cold-start/cache state.

--- a/docs/integration-devops.md
+++ b/docs/integration-devops.md
@@ -4,13 +4,6 @@
 
 [Back to README](../README.md)
 
-###
-This file is the module documentation template for Integration and DevOps.
-This section should later describe Docker, compose setup, environment wiring, and integration flow between modules.
-For now, it is a placeholder waiting for the module owner to complete it. 
-###
-
-
 ## Docker Compose Orchestration
 
 This section describes the Docker Compose setup for local development, covering the orchestration of API, database, and inference services.

--- a/docs/performance-benchmark.md
+++ b/docs/performance-benchmark.md
@@ -79,20 +79,20 @@ The JSON summary is machine-readable and includes:
 
 This benchmark is a single-run offline MP4 wall-clock measurement. The duration includes model loading, video decode, preprocessing, inference, event pipeline work, and any enabled context or bounding-box enrichment in the current config.
 
-It does not measure live camera capture-to-display latency, frontend rendering latency, network latency, or database persistence latency. For final reporting, run the benchmark more than once on the target machine and report the hardware, checkpoint, config, and device alongside the numbers.
+It does not measure live camera capture-to-display latency, frontend rendering latency, network latency, or database persistence latency. For reproducible reporting, run the benchmark more than once on the target machine and report the hardware, checkpoint, config, device, input video, and cold-start/cache state alongside the numbers.
 
-The final benchmark must be re-run after issue #130 publishes the final checkpoint. Until then, measurements from `baseline_epoch_50.pth` are smoke measurements only and must not be treated as final project performance.
+These measurements depend on the hardware, device, checkpoint, config, input video, and cold-start/cache state. They are throughput checks for the delivered setup, not model accuracy or quality validation.
 
-## Current Non-Final Smoke Measurements
+## Current Delivered-System Benchmark Measurements
 
-These measurements were captured locally on 2026-06-24 using `data/logs/checkpoints/baseline_epoch_50.pth`. That checkpoint is not the final checkpoint from issue #130, so every result in this table is a non-final smoke measurement only.
+These measurements were captured locally on 2026-06-24 using `data/logs/checkpoints/baseline_epoch_50.pth`.
 
 All three runs used the same MP4 input: `data/raw/car_makes_u_turn/0A2BF1E8-55E5-4D3D-9B7D-59929025D9CC_0.mp4`.
 
 | Run | Device/path | Frames | Inference windows | Events | Wall-clock duration | Approx processed FPS | Approx inference windows/s | Avg time/window | Notes |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
-| Docker CPU smoke | CPU in Docker, default Compose | `369` | `23` | `23` | `35.162069 s` | `10.494263` | `0.654114` | `1.528786 s` | Non-final smoke measurement using `baseline_epoch_50.pth`. Includes Docker/container initialization and model startup behavior. |
+| Docker CPU smoke | CPU in Docker, default Compose | `369` | `23` | `23` | `35.162069 s` | `10.494263` | `0.654114` | `1.528786 s` | Delivered-system smoke measurement using `baseline_epoch_50.pth`. Includes Docker/container initialization and model startup behavior. |
 | Local Python CPU smoke | CPU in local `.venv` | `369` | `23` | `23` | `26.020006 s` | `14.181396` | `0.883935` | `1.131305 s` | Not directly comparable with Docker because local Python used BBoxEnricher fallback behavior without `ultralytics` installed. |
-| Docker GPU smoke | CUDA in Docker with `compose.gpu.yaml` | `369` | `23` | `23` | `11.127545 s` | `33.160954` | `2.066943` | `0.483806 s` | Non-final smoke measurement using `baseline_epoch_50.pth`. Confirms the Docker CUDA path works, but final performance must be re-measured after #130. |
+| Docker GPU smoke | CUDA in Docker with `compose.gpu.yaml` | `369` | `23` | `23` | `11.127545 s` | `33.160954` | `2.066943` | `0.483806 s` | Delivered-system smoke measurement using `baseline_epoch_50.pth`. Confirms the Docker CUDA path works for the documented setup. |
 
-Final performance must be re-measured after issue #130 publishes the final checkpoint. Do not use these smoke measurements to claim that the project meets 15 FPS or <= 2 s end-to-end latency.
+Do not use these smoke measurements to claim model accuracy, model quality, universal performance, live camera latency, or compliance with a target that is not directly measured by this benchmark.


### PR DESCRIPTION
## Summary
Rework documentation to clarify checkpoint, demo, and benchmark wording: remove repeated “final”/issue #130 framing and present the current delivered/demo flows using data/logs/checkpoints/baseline_epoch_50.pth. Update README, architecture, final-demo-runbook, and performance-benchmark to describe smoke/delivered-system measurements (throughput checks, not accuracy or final performance) and to call out dependencies such as hardware, checkpoint, config, input video, and cold-start/cache state. Adjust runbook checkpoint/setup instructions and MP4 inference notes to reflect the documented checkpoint path and that smoke verification uses dummy checkpoints. Small wording tweaks throughout to improve operator clarity.

## Checklist
- [x] CI passes
- [x] README/docs updated